### PR TITLE
feat(llms): auto-generate llms-full.txt on push to main

### DIFF
--- a/.github/workflows/generate-llms-full.yml
+++ b/.github/workflows/generate-llms-full.yml
@@ -1,0 +1,43 @@
+name: Generate llms-full.txt
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  regenerate:
+    # Skip the run triggered by our own regenerate commit so we do not loop.
+    # We do not use [skip ci]: that would also stop Vercel from publishing the file.
+    if: "${{ !contains(github.event.head_commit.message, 'chore(llms): regenerate') }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # PAT so the push can re-deploy on Vercel and reach a protected main.
+          token: ${{ secrets.LLMS_FULL_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate llms-full.txt
+        run: yarn generate:llms
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add static/llms-full.txt
+          if git diff --staged --quiet; then
+            echo "llms-full.txt unchanged; nothing to commit."
+          else
+            git commit -m "chore(llms): regenerate llms-full.txt"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ build/
 tmp/
 
 package-lock.json
-
-llms-full.txt

--- a/scripts/generate-llms-full.mjs
+++ b/scripts/generate-llms-full.mjs
@@ -8,7 +8,7 @@ const repoRoot = path.resolve(scriptDir, '..');
 const docsRoot = path.join(repoRoot, 'src');
 const staticRoot = path.join(repoRoot, 'static');
 const sidebarPath = path.join(repoRoot, 'sidebars.js');
-const outputPath = path.join(repoRoot, 'llms-full.txt');
+const outputPath = path.join(staticRoot, 'llms-full.txt');
 const siteUrl = 'https://docs.concrete.xyz';
 
 function walk(dir, predicate = () => true) {
@@ -53,7 +53,7 @@ function publicStaticUrl(filePath) {
 function makeAssetIndex() {
   if (!fs.existsSync(staticRoot)) return '';
 
-  const files = walk(staticRoot)
+  const files = walk(staticRoot, (filePath) => filePath !== outputPath)
     .map((filePath) => ({
       path: path.relative(repoRoot, filePath).replace(/\\/g, '/'),
       url: publicStaticUrl(filePath),
@@ -83,6 +83,10 @@ function makeAssetIndex() {
   }
 
   return lines.join('\n').trim();
+}
+
+function contentWithoutTimestamp(content) {
+  return content.replace(/^Generated: .*$/m, '');
 }
 
 function normalizeDocBody(body) {
@@ -221,6 +225,12 @@ async function main() {
     makeAssetIndex(),
     '',
   ].join('\n');
+
+  const existing = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : null;
+  if (existing !== null && contentWithoutTimestamp(existing) === contentWithoutTimestamp(output)) {
+    console.log(`${path.relative(repoRoot, outputPath)} is already up to date; leaving it unchanged.`);
+    return;
+  }
 
   fs.writeFileSync(outputPath, output, 'utf8');
   console.log(`Wrote ${path.relative(repoRoot, outputPath)} with ${allDocs.length} docs and ${Buffer.byteLength(output)} bytes.`);


### PR DESCRIPTION
## Summary of changes

- Add `.github/workflows/generate-llms-full.yml`: on push to `main`, regenerates `llms-full.txt` and commits it using the `LLMS_FULL_KEY` secret. The job skips its own `chore(llms): regenerate` commit so it does not loop, and deliberately avoids `[skip ci]` so Vercel still redeploys the refreshed file.
- `scripts/generate-llms-full.mjs` now writes to `static/llms-full.txt`, so Docusaurus serves it at the site root (`/llms-full.txt`). The file is excluded from its own static asset index.
- The generator only rewrites the file when content other than the `Generated` timestamp changes, so identical regenerations leave the file and timestamp untouched.
- `.gitignore` no longer ignores `llms-full.txt` so the action can commit it.

The generated `static/llms-full.txt` is not committed here by design; the action creates it on the first run after merge.

Tested locally: no-op re-run leaves the file unchanged; a timestamp-only difference is treated as no change; a real content change triggers a rewrite; `yarn build` copies the file to `build/llms-full.txt`.

Jira Ticket: [CONC-3680](https://blueprintfinance.atlassian.net/browse/CONC-3680)

[CONC-3680]: https://blueprintfinance.atlassian.net/browse/CONC-3680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ