### PR TITLE
docs(vaults): align completed-campaigns with style-and-terminology guide

### DIFF
--- a/src/05-Vaults/completed-campaigns.md
+++ b/src/05-Vaults/completed-campaigns.md
@@ -1,32 +1,32 @@
 ---
 title: "Completed Campaigns"
-description: "Concrete vault documentation for deprecation Guide, including strategy behavior, withdrawals, migrations, and operational guidance."
+description: "Concrete vault documentation for completed campaigns, covering wind-down behavior, withdrawal paths, and how rewards remain claimable."
 sidebar_label: "Completed Campaigns"
 ---
 
-Concrete vaults operate as time-bounded campaigns. When a campaign reaches its end date, the vault transitions to withdraw-only mode through a controlled wind-down process. Once the campaign is completed, the vault is move to the Completed Campaigns section of the [Concrete App](https://app.concrete.xyz/). If you have ct[Assets] they are still accessible via the Portfolio section.
-During the wind-down, deposits are permanently disabled and strategies are deallocated. Depending on the vault's structure and underlying strategy, different mechanisms make funds available to depositors:
-- Async withdrawals (epoch-based queue processing)
-- Atomic withdrawals (single-transaction redemption)
-- Direct asset distribution to depositor wallets
+Some Concrete vaults run as time-bounded campaigns. When such a campaign reaches its end date, the vault transitions to withdraw-only mode through a controlled wind-down process. Once the campaign closes, the vault moves to the Completed Campaigns section of the [Concrete app](https://app.concrete.xyz/). If you still hold ctAssets from that vault, they remain accessible in the Portfolio tab.
+
+During the wind-down, deposits are permanently disabled and strategies are deallocated. The mechanism that returns funds to depositors depends on the vault's structure and strategy:
+
+- **Async withdrawal** – Requests are settled through the [Withdrawal Queue](./how-withdrawals-work.md) over one or more epochs.
+- **Instant withdrawal** – Redemption settles in a single transaction.
+- **Direct distribution** – Assets are sent directly to depositor wallets.
 
 For vaults hosted in partnership and displayed on the Concrete website, visit the partner's site for details about their specific wind-down process.
-If you deposited into any of the vaults listed in [Concrete App](https://app.concrete.xyz/) under Completed Campaigns, withdraw your funds promptly or contact the vault curator for guidance. Withdrawing early from closed campaigns ensures you retain full control over your assets and avoids delays.
+
+If you deposited into any vault listed in the [Concrete app](https://app.concrete.xyz/) under Completed Campaigns, withdraw your funds promptly or contact the vault curator for guidance. Withdrawing during the open window keeps you in full control of your assets and avoids delays.
 
 ## What Happens When a Campaign Closes
 
-Each closed campaign has a designated Withdrawal Period during which you can redeem your holdings and claim any earned rewards. The duration of this period may vary by vault.
-When a campaign closes, the following applies to your position within the Withdrawal Period:
+Each closed campaign has a withdrawal window during which you can redeem your holdings and claim any earned rewards. The duration varies by vault. Within that window, the following applies to your position:
 
-- **Deposits are permanently disabled** The vault no longer accepts new funds. 
-- **No new fees accrue** Fee parameters are set to zero to stop accrual. 
-- **Remaining balances stop earning yield** Strategies are deallocated and funds are returned to the vault.
-- **Withdrawal paths depend on the vault type** Check the dedicated vault page for details of the applied withdrawal path. 
-- **Previously earned rewards remain claimable** Reward eligibility is not affected by the campaign closing.
-- **The vault contract remains on-chain** The vault stays queryable for auditing after all depositors have exited. 
+- **Deposits are permanently disabled** – The vault no longer accepts new funds.
+- **No new fees accrue** – Fee parameters are set to zero to stop accrual.
+- **Remaining balances stop earning yield** – Strategies are deallocated and funds are returned to the vault.
+- **Withdrawal paths depend on the vault type** – Check the dedicated vault page for the applied withdrawal path.
+- **Previously earned rewards remain claimable** – Reward eligibility is not affected by the campaign closing.
+- **The vault contract remains on-chain** – The vault stays queryable for auditing after all depositors have exited.
 
-If you do not withdraw during the Withdrawal Period, your holdings may be migrated to a new vault, and any unclaimed rewards may be forfeited.
-For full details on the Withdrawal Period and what it means for your position, see the [Terms of Use](https://concrete.xyz/terms).
+If you do not withdraw during the open window, your holdings may be migrated to a new vault, and any unclaimed rewards may be forfeited. For the full terms covering this period, see the [Terms of Use](https://concrete.xyz/terms).
 
-For more on support, see [Support](/support/)
-For more on withdrawals, see [Support](/Vaults/how-withdrawals-work/)
+For more on support, see [Support](/support/). For more on withdrawals, see [How Withdrawals Work](/Vaults/how-withdrawals-work/).


### PR DESCRIPTION
## Summary of changes

Stack-on review pass for the new `completed-campaigns.md` page created on CONC-3728. Applies the rules in `STYLE-AND-TERMINOLOGY.md`.

- Corrected the frontmatter `description` (still referenced the old deprecation guide).
- Fixed `is move` typo and `ct[Assets]` placeholder leak (canonical `ctAssets`).
- Constrained the "all vaults are time-bounded campaigns" claim to vaults that actually run as campaigns.
- Reformatted bullet lists to the `**Label** – explanation` form required by section 5.2 of the style guide.
- Replaced the second mis-labeled `[Support]` link with `[How Withdrawals Work]`.
- Switched to canonical "async withdrawal" / "instant withdrawal" terms.

## Review notes

Targeting `CONC-3728` rather than `main` so the original author can review this style-guide pass before that branch merges. Build verified locally (`yarn build` succeeds).

Jira ticket: [CONC-3728](https://blueprintfinance.atlassian.net/browse/CONC-3728)

[CONC-3728]: https://blueprintfinance.atlassian.net/browse/CONC-3728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ