### PR TITLE
fix(llms): generate llms-full.txt on PR branch instead of main

### DIFF
--- a/.github/actions/sync-and-regenerate/action.yml
+++ b/.github/actions/sync-and-regenerate/action.yml
@@ -1,0 +1,66 @@
+name: Sync and regenerate llms-full.txt
+description: >
+  Merges origin/main into the currently checked-out branch (auto-resolving
+  static/llms-full.txt by keeping ours), regenerates the file, and pushes
+  the merge commit plus any regeneration commit back to the branch. If
+  conflicts exist outside static/llms-full.txt, the merge is aborted and the
+  branch is left untouched for humans to resolve.
+
+runs:
+  using: composite
+  steps:
+    - name: Configure git identity
+      shell: bash
+      run: |
+        git config user.name  "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Sync with main, accepting our llms-full.txt on conflict
+      id: sync
+      shell: bash
+      run: |
+        git fetch origin main
+        if git merge-base --is-ancestor origin/main HEAD; then
+          echo "Branch already up to date with main."
+        else
+          if ! git merge origin/main --no-edit -X ours; then
+            remaining=$(git ls-files -u | awk '{print $4}' | sort -u | grep -v '^static/llms-full.txt$' || true)
+            if [ -n "$remaining" ]; then
+              echo "Conflicts outside static/llms-full.txt; leaving branch untouched:"
+              echo "$remaining"
+              git merge --abort
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            git checkout --ours static/llms-full.txt
+            git add static/llms-full.txt
+            git commit --no-edit
+          fi
+        fi
+
+    - name: Setup Node.js
+      if: steps.sync.outputs.skip != 'true'
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: yarn
+
+    - name: Install dependencies
+      if: steps.sync.outputs.skip != 'true'
+      shell: bash
+      run: yarn install --frozen-lockfile
+
+    - name: Generate llms-full.txt
+      if: steps.sync.outputs.skip != 'true'
+      shell: bash
+      run: yarn generate:llms
+
+    - name: Commit and push if changed
+      if: steps.sync.outputs.skip != 'true'
+      shell: bash
+      run: |
+        git add static/llms-full.txt
+        if ! git diff --staged --quiet; then
+          git commit -m "chore(llms): regenerate llms-full.txt"
+        fi
+        git push

--- a/.github/workflows/generate-llms-full.yml
+++ b/.github/workflows/generate-llms-full.yml
@@ -8,41 +8,64 @@ on:
       - 'src/**/*.mdx'
       - 'sidebars.js'
       - 'scripts/generate-llms-full.mjs'
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
-  regenerate:
-    # Skip fork PRs: GITHUB_TOKEN is read-only from forks and can't push back.
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+  regenerate-on-pr:
+    # PR events from the same repo (forks get a read-only token and can't push back).
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
+      - uses: Blueprint-Finance/concrete-docs/.github/actions/sync-and-regenerate@main
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Generate llms-full.txt
-        run: yarn generate:llms
-
-      - name: Commit if changed
+  regenerate-on-command:
+    # Comment '/sync-llms' on an open PR by a collaborator forces a resync + regen.
+    # Useful when a previous run couldn't auto-resolve a conflict outside llms-full.txt
+    # and the PR's been resolved manually but still has a stale generated file.
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open' &&
+      contains(github.event.comment.body, '/sync-llms') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR head ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add static/llms-full.txt
-          if git diff --staged --quiet; then
-            echo "llms-full.txt unchanged; nothing to commit."
-          else
-            git commit -m "chore(llms): regenerate llms-full.txt"
-            git push
+          pr=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          ref=$(echo "$pr" | jq -r .head.ref)
+          repo=$(echo "$pr" | jq -r .head.repo.full_name)
+          if [ "$repo" != "${{ github.repository }}" ]; then
+            echo "PR is from a fork; cannot push back. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          fetch-depth: 0
+
+      - if: steps.pr.outputs.skip != 'true'
+        uses: Blueprint-Finance/concrete-docs/.github/actions/sync-and-regenerate@main

--- a/.github/workflows/generate-llms-full.yml
+++ b/.github/workflows/generate-llms-full.yml
@@ -1,22 +1,27 @@
 name: Generate llms-full.txt
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**/*.md'
+      - 'src/**/*.mdx'
+      - 'sidebars.js'
+      - 'scripts/generate-llms-full.mjs'
+
+permissions:
+  contents: write
 
 jobs:
   regenerate:
-    # Skip the run triggered by our own regenerate commit so we do not loop.
-    # We do not use [skip ci]: that would also stop Vercel from publishing the file.
-    if: "${{ !contains(github.event.head_commit.message, 'chore(llms): regenerate') }}"
+    # Skip fork PRs: GITHUB_TOKEN is read-only from forks and can't push back.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          # PAT so the push can re-deploy on Vercel and reach a protected main.
-          token: ${{ secrets.LLMS_FULL_KEY }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary of changes

Replaces the `push: main` trigger with a `pull_request: main` trigger plus a `/sync-llms` comment trigger, and adds proactive auto-sync of the PR branch against `main` on every run. Three pieces:

**1. `pull_request` trigger** (replaces the old `push: main`)
- Fires on PR open/sync/reopen targeting `main`, scoped by `paths:` (`src/**/*.md`, `src/**/*.mdx`, `sidebars.js`, `scripts/generate-llms-full.mjs`).
- Job checks out the PR's head ref, runs the shared composite action, and pushes the regenerated `static/llms-full.txt` back to the PR branch. The file lands on `main` atomically with the PR merge; no push to protected `main` is needed.
- Skips fork PRs (token is read-only there).

**2. Proactive auto-sync with `main`** (in the composite action)
- Each run merges `origin/main` into the PR branch with `-X ours` for `static/llms-full.txt`, then regenerates the file. PR stays current with `main` and `llms-full.txt` is always consistent with the merged tree.
- If the merge hits a conflict outside `static/llms-full.txt`, the merge is aborted and the branch is left untouched. The bot never pushes a half-merged tree.

**3. `/sync-llms` comment trigger** (second job)
- Posting `/sync-llms` on an open PR (by owner/member/collaborator) re-runs the same sync+regen flow on demand. Recovers stuck branches where the routine PR-event run couldn't auto-resolve and a human resolved the non-llms conflicts manually.

**Other changes**
- Uses the default `GITHUB_TOKEN` with `permissions: contents: write, pull-requests: read`, dropping `LLMS_FULL_KEY` entirely (the secret can be deleted after merge).
- Shared sync+regen logic lives in `.github/actions/sync-and-regenerate` and is referenced by both jobs via `@main` so existing open PRs don't need to pull this PR in to use it.
- Drops the commit-message loop guard: redundant under the new design (path filter + `GITHUB_TOKEN` recursion guard + the composite action only ever touches `static/llms-full.txt`).

Fixes the protected-branch push rejection seen on https://github.com/Blueprint-Finance/concrete-docs/actions/runs/26471333520.

Follow-up to [CONC-3680](https://blueprintfinance.atlassian.net/browse/CONC-3680).

[CONC-3680]: https://blueprintfinance.atlassian.net/browse/CONC-3680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ