### PR TITLE
docs(fees): update fees article with cooldown exit and hurdle rate

### DIFF
--- a/src/02-Using-Concrete-Vaults/fees.md
+++ b/src/02-Using-Concrete-Vaults/fees.md
@@ -6,24 +6,28 @@ sidebar_position: 4
 ---
 
 Concrete offers a transparent fee structure, ensuring competitive rates across its ecosystem.
-Two fee types are available — a management fee and a performance fee — but not every vault applies both. Each vault's fee configuration depends on its strategy and commercial terms. Both fees are paid by minting vault shares to a fee recipient rather than transferring the underlying asset, so the cost is reflected directly in the share price.
+
+**Not every vault applies all the fees. Each vault's fee configuration depends on its strategy and commercial terms.** Fees are paid by minting vault shares to a fee recipient rather than transferring the underlying asset, so the cost is reflected directly in the share price.
 
 ## Fee summary
 
-| **Fee Type**        | **Range** | **Description**                                                                                               |
-|---------------------|------------------|--------------------------------------------------------------------------------------------------------------|
-| Deposit Fee         | None       | No fees on deposits |
-| Withdrawal Fee         | None       | No fees on withdrawals |
-| Management Fee      | 0-10% of AUM |Annualized charge on vault AUM, accrued continuously based on time elapsed.Configured per vault, with a standard rate of 1.5% applied to most vaults — see individual vault pages for rates applied to your vault. |
-| Performance Fee     | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault — see individual vault pages for current rates. |
+| Fee type | Range | Description |
+| --- | --- | --- |
+| Deposit fee | None | No fees on deposits. |
+| Withdrawal fee | None | No fees on withdrawals. |
+| Cooldown Exit fee | 0–1% of position | The Withdrawal Cooldown can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
+| Management fee | 0–10% of AUM | Annualized charge on vault AUM, accrued continuously based on time elapsed. Configured per vault, with a standard rate of 1.5% applied to most vaults. See individual vault pages for rates applied to your vault. |
+| Performance fee | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault. See individual vault pages for current rates. |
+| Hurdle rate on Performance fee | 0–30% of net positive yield | Target return (the hurdle) is defined for depositors, and fees apply only to yield generated above that threshold. Yield up to the hurdle is distributed to depositors. **Fixed APY** is a constant annualized target that compounds. **Fixed APR** is a constant annualized target calculated on a simple (non-compounding) basis. **Dynamic hurdle** is a variable target that adjusts based on external rate. |
 
-Actual rates are configured per vault — refer to individual vault pages for current values.
+Actual rates are configured per vault. Refer to individual vault pages for current values.
+
 Because fees are paid in shares, existing shareholders are diluted proportionally rather than charged separately. Every fee accrual emits on-chain events indexed by Concrete's subgraph, so share-price impact is observable in real time.
 
 ## How fees accrue
 
 Fees are calculated as part of the vault's yield accrual process, in this order:
 
-1. **Yield and loss update** — Each strategy's current value is compared to its last recorded value.
-2. **Management fee** — Accrues on the updated total assets, calculated based on time elapsed since the last accrual.
-3. **Performance fee** — Accrues on net positive yield (gains minus losses). If there is no net positive yield, no performance fee is charged.
+1. **Yield and loss update.** Each strategy's current value is compared to its last recorded value.
+2. **Management fee.** Accrues on the updated total assets, calculated based on time elapsed since the last accrual.
+3. **Performance fee.** Accrues on net positive yield (gains minus losses). If there is no net positive yield, no performance fee is charged.

--- a/src/02-Using-Concrete-Vaults/fees.md
+++ b/src/02-Using-Concrete-Vaults/fees.md
@@ -5,9 +5,9 @@ sidebar_label: "Fees"
 sidebar_position: 4
 ---
 
-Concrete offers a transparent fee structure, ensuring competitive rates across its ecosystem.
+Concrete offers a transparent fee structure, ensuring competitive rates across its ecosystem. Not every vault applies all the fees. Each vault's fee configuration depends on its strategy and commercial terms.
 
-**Not every vault applies all the fees. Each vault's fee configuration depends on its strategy and commercial terms.** Fees are paid by minting vault shares to a fee recipient rather than transferring the underlying asset, so the cost is reflected directly in the share price.
+Fees are paid by minting vault shares to a fee recipient rather than transferring the underlying asset, so the cost is reflected directly in the share price.
 
 ## Fee summary
 

--- a/src/02-Using-Concrete-Vaults/fees.md
+++ b/src/02-Using-Concrete-Vaults/fees.md
@@ -18,7 +18,7 @@ Concrete offers a transparent fee structure, ensuring competitive rates across i
 | Cooldown Exit fee | 0–1% of position | The Withdrawal Cooldown can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
 | Management fee | 0–10% of position | Annualized charge on vault AUM, accrued continuously based on time elapsed. Configured per vault, with a standard rate of 1.5% applied to most vaults. See individual vault pages for rates applied to your vault. |
 | Performance fee | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault. See individual vault pages for current rates. |
-| Hurdle rate on Performance fee | 0–30% of net positive yield | Target return (the hurdle) is defined for depositors, and fees apply only to yield generated above that threshold. Yield up to the hurdle is distributed to depositors. **Fixed APY** is a constant annualized target that compounds. **Fixed APR** is a constant annualized target calculated on a simple (non-compounding) basis. **Dynamic hurdle** is a variable target that adjusts based on external rate. |
+| Hurdle rate on Performance fee | 0–30% of net positive yield | Target return (the hurdle) is defined for depositors, and fees apply only to yield generated above that threshold. Yield up to the hurdle is distributed to depositors.<br /><br />**Fixed APY** – a constant annualized target that compounds.<br />**Fixed APR** – a constant annualized target calculated on a simple (non-compounding) basis.<br />**Dynamic hurdle** – a variable target that adjusts based on external rate. |
 
 Actual rates are configured per vault. Refer to individual vault pages for current values.
 

--- a/src/02-Using-Concrete-Vaults/fees.md
+++ b/src/02-Using-Concrete-Vaults/fees.md
@@ -16,7 +16,7 @@ Concrete offers a transparent fee structure, ensuring competitive rates across i
 | Deposit fee | None | No fees on deposits. |
 | Withdrawal fee | None | No fees on withdrawals. |
 | Cooldown Exit fee | 0–1% of position | The Withdrawal Cooldown can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
-| Management fee | 0–10% of AUM | Annualized charge on vault AUM, accrued continuously based on time elapsed. Configured per vault, with a standard rate of 1.5% applied to most vaults. See individual vault pages for rates applied to your vault. |
+| Management fee | 0–10% of position | Annualized charge on vault AUM, accrued continuously based on time elapsed. Configured per vault, with a standard rate of 1.5% applied to most vaults. See individual vault pages for rates applied to your vault. |
 | Performance fee | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault. See individual vault pages for current rates. |
 | Hurdle rate on Performance fee | 0–30% of net positive yield | Target return (the hurdle) is defined for depositors, and fees apply only to yield generated above that threshold. Yield up to the hurdle is distributed to depositors. **Fixed APY** is a constant annualized target that compounds. **Fixed APR** is a constant annualized target calculated on a simple (non-compounding) basis. **Dynamic hurdle** is a variable target that adjusts based on external rate. |
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Concrete Docs - LLM Full Context
 
-Generated: 2026-05-29T12:22:34.237Z
+Generated: 2026-06-01T14:08:30.355Z
 Source repository: concrete-docs
 Canonical docs URL: https://docs.concrete.xyz/
 
@@ -122,11 +122,11 @@ Where the yield comes from depends on the specific vault's strategy, which is ma
 
 Concrete offers three ERC-4626 vault implementations, each suited to a different operational pattern. All three share a common base: full ERC-4626 compliance, multi-strategy support, fee management, hooks, and role-based access control.
 
-- **Standard (Atomic) Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
-- **Queued Withdrawal Vault** – Adds an epoch-based withdrawal queue to the Standard vault, where requests are collected during an epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
-- **Pre-deposit (Cross Chain) Vault** – Extends the Standard vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch.
+- **Atomic Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
+- **Queued Withdrawal Vault** – Adds an epoch-based withdrawal queue to the Atomic vault, where requests are collected during an epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
+- **Pre-deposit (Cross Chain) Vault** – Extends the Atomic vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch.
 
-Because they share this base, the Queued Withdrawal and Pre-deposit vaults retain every capability of the Standard vault.
+Because they share this base, the Queued Withdrawal and Pre-deposit vaults retain every capability of the Atomic vault.
 
 ### Limits to Be Aware Of
 
@@ -251,69 +251,65 @@ Source: src/02-Using-Concrete-Vaults/withdraw.md
 Doc ID: Using-Concrete-Vaults/withdraw
 Public URL: https://docs.concrete.xyz/Using-Concrete-Vaults/withdraw/
 In active sidebar: yes
-Description: Withdrawal documentation for Concrete vaults, covering vault types, the Withdrawal Queue, epoch cadence, and withdrawal caps.
-Withdrawal behavior depends on the vault. Most Concrete Earn vaults are async vaults: you submit a withdrawal request, the vault groups requests into epochs, processes them on a schedule, and makes the funds available to claim from the **Portfolio** tab. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
+Description: Withdrawal documentation for Concrete vaults, covering vault types, the Withdrawal Queue, Epoch cadence, and withdrawal caps.
+Withdrawal behavior depends on the vault. Most Concrete vaults are Queued Withdrawal Vaults: you submit a withdrawal request, the vault groups requests into Epochs, processes them on a schedule, and makes the funds available to claim from the vault page. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
 
 ## Vault Types and Withdrawal Behavior
 
-Concrete Earn ships two vault implementations and one launch-time variant, each with different withdrawal behavior:
+Concrete ships two vault implementations and one launch-time variant, each with different withdrawal behavior:
 
-- **Async vault** – settles withdrawals through the **Withdrawal Queue**. Used whenever the strategy cannot return assets atomically, for example positions held in a multi-sig wallet for off-chain or multi-venue execution, Pendle LP unwinds, or money markets with withdrawal cooldowns. This is the most common configuration on Concrete.
-- **Standard (atomic) vault** – `withdraw()` and `redeem()` execute in a single transaction. Used when the underlying strategy can return assets immediately.
-- **Pre-deposit vault** – accepts deposits on one chain before the target vault launches on another. Exit is via a cross-chain share claim, not the Withdrawal Queue. See [Pre-Deposit (Cross-Chain) Vault](#pre-deposit-cross-chain-vault) below.
+- **Atomic Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
+- **Queued Withdrawal Vault** – Adds an Epoch-based withdrawal queue to the Atomic vault, where requests are collected during an Epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
+- **Pre-deposit (Cross Chain) Vault** – Extends the Atomic vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch. See [Pre-deposit (Cross Chain) Vault](#pre-deposit-cross-chain-vault) below.
 
-## Async Vault (Withdrawal Queue)
+## Atomic Vault
 
-1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet. Your ct[Asset] shares are held by the vault and the request joins the current epoch.
-2. **The cutoff passes.** At the vault's scheduled cutoff, the epoch closes to new requests. You can cancel up to the cutoff; once it passes, the request is locked in and a new epoch opens.
-3. **The epoch is processed.** Shortly after the cutoff:
-   - The share price for the epoch is locked in at that moment, not at request time.
+An Atomic Vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
+
+1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet.
+2. **The vault settles.** The vault deallocates from strategies in its configured order to cover the withdrawal.
+3. **Receive your assets.** Your shares are burned and the underlying asset is transferred to your wallet in the same transaction.
+
+## Queued Withdrawal Vault
+
+1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet. Your ct[Asset] shares are held by the vault and the request joins the current Epoch.
+2. **The cutoff passes.** At the vault's scheduled cutoff, the Epoch closes to new requests. You can cancel up to the cutoff; once it passes, the request is locked in and a new Epoch opens.
+3. **The Epoch is processed.** Shortly after the cutoff:
+   - The share price for the Epoch is locked in at that moment, not at request time.
    - Your shares are burned.
    - Your assets are reserved for you to claim. They come from the vault's unallocated balance first (idle deposits and previous unwind leftovers); if that is not enough, the **Allocator** deallocates from strategies to cover the difference.
-4. **Claim your assets.** Your withdrawal status moves to **Available** in the Portfolio tab. Click Claim, confirm in your wallet, and the assets arrive in your wallet. If you have multiple withdrawals ready across different epochs, you can claim them together.
+4. **Claim your assets.** Your withdrawal status moves to **Available** in the vault page. Click Claim, confirm in your wallet, and the assets arrive in your wallet. If you have multiple withdrawals ready across different Epochs, you can claim them together.
 
-You can track each request in the **Portfolio** tab with status labels **Queued**, **Processing**, and **Available**. The app shows an **estimated withdrawal time** based on the vault's cadence and queue depth.
+You can track each request in the vault page with status labels **Queued**, **Processing**, and **Available**. The app shows an **estimated withdrawal time** based on the vault's cadence and queue depth.
 
 ### Withdrawal Caps Per Epoch
 
-Some vaults set a withdrawal cap that limits the total volume of redemptions processed in a single epoch, expressed as a percentage of vault TVL. Whether a cap is enabled, and at what threshold, is set by the vault curator based on the strategy's liquidity profile and unwind capacity. Not all vaults use caps. Caps work alongside cadence to keep epoch sizes aligned with the strategy's unwind capacity.
+Some vaults set a withdrawal cap that limits the total volume of redemptions processed in a single Epoch, expressed as a percentage of vault TVL. Whether a cap is enabled, and at what threshold, is decided per vault based on the strategy's liquidity profile and unwind capacity. Not all vaults use caps. Caps work alongside cadence to keep Epoch sizes aligned with the strategy's unwind capacity.
 
-To check the exact redemption process, including whether a cap is active and at what threshold, visit the withdrawal management page for the vault.
+To check the exact redemption process, including whether a cap is active and at what threshold, visit the specific vault's page.
 
 **How caps behave**
 
-When requests in an epoch stay under the cap, the epoch processes normally at the scheduled time. When requests exceed the cap, only requests up to the cap threshold are processed in that epoch. The remainder roll forward to subsequent epochs and are processed in the order they were originally requested (First In, First Out). Depositors waiting across multiple epochs continue earning yield until their portion is processed.
+When requests in an Epoch stay under the cap, the Epoch processes normally at the scheduled time. When requests exceed the cap, only requests up to the cap threshold are processed in that Epoch. The remainder roll forward to subsequent Epochs and are processed in the order they were originally requested (First In, First Out). Depositors waiting across multiple Epochs continue earning yield until their portion is processed.
 
 :::info[Example: weekly vault with withdrawal cap]
-Say a vault processes withdrawals every Tuesday with a cap of 20% of TVL per epoch.
+Say a vault processes withdrawals every Tuesday with a cap of 20% of TVL per Epoch.
 
-If Alice submits a withdrawal request on Friday, May 29, her request joins the queue for the next epoch on Tuesday, June 3. If total requests that week are under the 20% cap, Alice receives her funds by Friday, June 6.
+If Alice submits a withdrawal request on Friday, May 29, her request joins the queue for the next Epoch on Tuesday, June 3. If total requests that week are under the 20% cap, Alice receives her funds by Friday, June 6.
 
-If requests in a given epoch exceed the cap, the queue processes them in the order they were submitted (FIFO) across subsequent epochs. Alice continues earning yield on her position while she waits, and her funds are returned as her place in the queue is reached.
+If requests in a given Epoch exceed the cap, the queue processes them in the order they were submitted (FIFO) across subsequent Epochs. Alice continues earning yield on her position while she waits, and her funds are returned as her place in the queue is reached.
 :::
 
-### Cadence of Epochs
+### Things to Know About Queued Withdrawal Vaults
 
-Different vaults run on different epoch schedules, which determines how often withdrawals are processed. The default cadence is one epoch per week. The Concrete DeFi USDT vault runs two epochs per week, so under normal load its queue settles within 3.5 to 7 days; if requests exceed the vault's withdrawal cap, the queue extends until later epochs settle the remainder. Each vault's page lists its specific schedule.
+- **Withdrawals are not instant** – there is a delay between requesting and receiving your funds, set by the vault's Epoch schedule and the time needed to deallocate from strategies.
+- **Your share price is set at processing, not at request** – the share price applied to your withdrawal is locked in when the Epoch is processed, so your final amount can move up or down between submission and settlement.
+- **You keep your position until the Epoch is processed** – your shares sit with the vault and are not burned until processing happens.
+- **You can cancel, but only before the cutoff** – once the Epoch closes, the request is locked in and cannot be cancelled.
+- **Requests can roll into the next Epoch** – when an Epoch hits the cap or processing is delayed, the remainder of a request can move to the next Epoch.
+- **Each vault sets minimum and maximum withdrawal sizes** – your request must fall within these limits.
 
-### Things to Know About Async Vaults
-
-- **Withdrawals are not instant** – there is a delay between requesting and receiving your funds, set by the vault's epoch schedule and the time needed to deallocate from strategies.
-- **Your share price is set at processing, not at request** – the share price applied to your withdrawal is locked in when the epoch is processed, so your final amount can move up or down between submission and settlement.
-- **You keep your position until the epoch is processed** – your shares sit with the vault and are not burned until processing happens.
-- **You can cancel, but only before the cutoff** – once the epoch closes, the request is locked in and cannot be cancelled.
-- **Requests can roll into the next epoch** – when an epoch hits the cap or processing is delayed, the **Withdrawal Manager** can move a request to the next epoch.
-- **Each vault sets minimum and maximum withdrawal sizes** – your request must fall within these limits. Some vaults can also pause new withdrawal requests entirely.
-
-## Standard (Atomic) Vault
-
-A standard vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
-
-1. On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet.
-2. The vault deallocates from strategies in its configured order to cover the withdrawal.
-3. Your shares are burned and the underlying asset is transferred to your wallet in the same transaction.
-
-## Pre-Deposit (Cross-Chain) Vault
+## Pre-deposit (Cross Chain) Vault
 
 Some Concrete vaults are pre-deposit vaults, designed for launches where you deposit on one chain and receive shares on another. These do not use the Withdrawal Queue; instead, you claim your shares on the destination chain when the vault is ready.
 
@@ -328,9 +324,9 @@ When a pre-deposit vault enters its claim phase, the vault page in the Concrete 
 
 ## Frequently Asked Questions
 
-- **Do my shares continue earning yield while in the queue?** Shares are held by the vault and are not burned until `processEpoch()` runs. Share price is locked at processing time, so any yield (or loss) the vault records between request and processing is reflected in the price applied to the request.
-- **Can I cancel a withdrawal request?** Yes, for the current open epoch only, you can cancel on the vault page. Once the cutoff passes, the request cannot be cancelled.
-- **What happens if my request cannot be filled in its epoch?** When the epoch reaches its withdrawal cap or processing is delayed, the **Withdrawal Manager** moves the remainder to the next epoch via `moveRequestToNextEpoch()`. Your queue position is preserved (FIFO).
+- **Do my shares continue earning yield while in the queue?** Shares are held by the vault and are not burned until the Epoch is processed. Share price is locked at processing time, so any yield (or loss) the vault records between request and processing is reflected in the price applied to the request.
+- **Can I cancel a withdrawal request?** Yes, for the current open Epoch only, you can cancel on the vault page. Once the cutoff passes, the request cannot be cancelled.
+- **What happens if my request cannot be filled in its Epoch?** When the Epoch reaches its withdrawal cap, the remainder of your withdrawal request is moved to the next Epoch. Your queue position is preserved (FIFO).
 
 ---
 
@@ -403,28 +399,32 @@ Doc ID: Using-Concrete-Vaults/fees
 Public URL: https://docs.concrete.xyz/Using-Concrete-Vaults/fees/
 In active sidebar: yes
 Description: Complete fee reference for Concrete products, including how fees are calculated, applied, and communicated across workflows.
-Concrete offers a transparent fee structure, ensuring competitive rates across its ecosystem.
-Two fee types are available — a management fee and a performance fee — but not every vault applies both. Each vault's fee configuration depends on its strategy and commercial terms. Both fees are paid by minting vault shares to a fee recipient rather than transferring the underlying asset, so the cost is reflected directly in the share price.
+Concrete offers a transparent fee structure, ensuring competitive rates across its ecosystem. Not every vault applies all the fees. Each vault's fee configuration depends on its strategy and commercial terms.
+
+Fees are paid by minting vault shares to a fee recipient rather than transferring the underlying asset, so the cost is reflected directly in the share price.
 
 ## Fee summary
 
-| **Fee Type**        | **Range** | **Description**                                                                                               |
-|---------------------|------------------|--------------------------------------------------------------------------------------------------------------|
-| Deposit Fee         | None       | No fees on deposits |
-| Withdrawal Fee         | None       | No fees on withdrawals |
-| Management Fee      | 0-10% of AUM |Annualized charge on vault AUM, accrued continuously based on time elapsed.Configured per vault, with a standard rate of 1.5% applied to most vaults — see individual vault pages for rates applied to your vault. |
-| Performance Fee     | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault — see individual vault pages for current rates. |
+| Fee type | Range | Description |
+| --- | --- | --- |
+| Deposit fee | None | No fees on deposits. |
+| Withdrawal fee | None | No fees on withdrawals. |
+| Cooldown Exit fee | 0–1% of position | The Withdrawal Cooldown can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
+| Management fee | 0–10% of position | Annualized charge on vault AUM, accrued continuously based on time elapsed. Configured per vault, with a standard rate of 1.5% applied to most vaults. See individual vault pages for rates applied to your vault. |
+| Performance fee | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault. See individual vault pages for current rates. |
+| Hurdle rate on Performance fee | 0–30% of net positive yield | Target return (the hurdle) is defined for depositors, and fees apply only to yield generated above that threshold. Yield up to the hurdle is distributed to depositors.<br /><br />**Fixed APY** – a constant annualized target that compounds.<br />**Fixed APR** – a constant annualized target calculated on a simple (non-compounding) basis.<br />**Dynamic hurdle** – a variable target that adjusts based on external rate. |
 
-Actual rates are configured per vault — refer to individual vault pages for current values.
+Actual rates are configured per vault. Refer to individual vault pages for current values.
+
 Because fees are paid in shares, existing shareholders are diluted proportionally rather than charged separately. Every fee accrual emits on-chain events indexed by Concrete's subgraph, so share-price impact is observable in real time.
 
 ## How fees accrue
 
 Fees are calculated as part of the vault's yield accrual process, in this order:
 
-1. **Yield and loss update** — Each strategy's current value is compared to its last recorded value.
-2. **Management fee** — Accrues on the updated total assets, calculated based on time elapsed since the last accrual.
-3. **Performance fee** — Accrues on net positive yield (gains minus losses). If there is no net positive yield, no performance fee is charged.
+1. **Yield and loss update.** Each strategy's current value is compared to its last recorded value.
+2. **Management fee.** Accrues on the updated total assets, calculated based on time elapsed since the last accrual.
+3. **Performance fee.** Accrues on net positive yield (gains minus losses). If there is no net positive yield, no performance fee is charged.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace fees article body with the canonical content provided for the new IA.
- Add **Cooldown Exit fee** (0–1% of position) and **Hurdle rate on Performance fee** (0–30% of net positive yield) rows to the fee summary table.
- Tighten the intro to call out that not every vault applies all fees.
- Drop em-dashes per `STYLE-AND-TERMINOLOGY.md`.

Stacked on top of #123 (CONC-3738). Will auto-rebase against `main` once #123 merges.