### PR TITLE
docs(withdraw): address kar-mal review on #117

### DIFF
--- a/src/01-Overview/yield-vaults-and-erc-4626-standard.md
+++ b/src/01-Overview/yield-vaults-and-erc-4626-standard.md
@@ -23,11 +23,11 @@ Where the yield comes from depends on the specific vault's strategy, which is ma
 
 Concrete offers three ERC-4626 vault implementations, each suited to a different operational pattern. All three share a common base: full ERC-4626 compliance, multi-strategy support, fee management, hooks, and role-based access control.
 
-- **Standard (Atomic) Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
-- **Queued Withdrawal Vault** – Adds an epoch-based withdrawal queue to the Standard vault, where requests are collected during an epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
-- **Pre-deposit (Cross Chain) Vault** – Extends the Standard vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch.
+- **Atomic Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
+- **Queued Withdrawal Vault** – Adds an epoch-based withdrawal queue to the Atomic vault, where requests are collected during an epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
+- **Pre-deposit (Cross Chain) Vault** – Extends the Atomic vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch.
 
-Because they share this base, the Queued Withdrawal and Pre-deposit vaults retain every capability of the Standard vault.
+Because they share this base, the Queued Withdrawal and Pre-deposit vaults retain every capability of the Atomic vault.
 
 ### Limits to Be Aware Of
 

--- a/src/02-Using-Concrete-Vaults/withdraw.md
+++ b/src/02-Using-Concrete-Vaults/withdraw.md
@@ -4,25 +4,25 @@ description: "Withdrawal documentation for Concrete vaults, covering vault types
 sidebar_label: "Withdraw"
 ---
 
-Withdrawal behavior depends on the vault. Most Concrete vaults are async vaults: you submit a withdrawal request, the vault groups requests into Epochs, processes them on a schedule, and makes the funds available to claim from the vault page. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
+Withdrawal behavior depends on the vault. Most Concrete vaults are Queued Withdrawal Vaults: you submit a withdrawal request, the vault groups requests into Epochs, processes them on a schedule, and makes the funds available to claim from the vault page. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
 
 ## Vault Types and Withdrawal Behavior
 
 Concrete ships two vault implementations and one launch-time variant, each with different withdrawal behavior:
 
-- **Atomic vault** – `withdraw()` and `redeem()` execute in a single transaction. Used when the underlying strategy can return assets immediately. Withdrawn assets are returned to the depositor instantly.
-- **Async vault** – settles withdrawals through the **Withdrawal Queue**. Used whenever the strategy cannot return assets atomically, for example positions held in a multi-sig wallet for off-chain or multi-venue execution, Pendle LP unwinds, or money markets with withdrawal cooldowns. A depositor submits a withdrawal request and waits in the queue for a predefined period. This is the most common configuration on Concrete.
-- **Pre-deposit vault** – accepts deposits on one chain before the target vault launches on another. Exit is via a cross-chain share claim, not the Withdrawal Queue. See [Pre-Deposit (Cross-Chain) Vault](#pre-deposit-cross-chain-vault) below.
+- **Standard (Atomic) Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
+- **Queued Withdrawal Vault** – Adds an Epoch-based withdrawal queue to the Standard vault, where requests are collected during an Epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
+- **Pre-deposit (Cross Chain) Vault** – Extends the Standard vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch. See [Pre-deposit (Cross Chain) Vault](#pre-deposit-cross-chain-vault) below.
 
-## Atomic Vault
+## Standard (Atomic) Vault
 
-An atomic vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
+A Standard (Atomic) Vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
 
 1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet.
 2. **The vault settles.** The vault deallocates from strategies in its configured order to cover the withdrawal.
 3. **Receive your assets.** Your shares are burned and the underlying asset is transferred to your wallet in the same transaction.
 
-## Async Vault (Withdrawal Queue)
+## Queued Withdrawal Vault
 
 1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet. Your ct[Asset] shares are held by the vault and the request joins the current Epoch.
 2. **The cutoff passes.** At the vault's scheduled cutoff, the Epoch closes to new requests. You can cancel up to the cutoff; once it passes, the request is locked in and a new Epoch opens.
@@ -52,7 +52,7 @@ If Alice submits a withdrawal request on Friday, May 29, her request joins the q
 If requests in a given Epoch exceed the cap, the queue processes them in the order they were submitted (FIFO) across subsequent Epochs. Alice continues earning yield on her position while she waits, and her funds are returned as her place in the queue is reached.
 :::
 
-### Things to Know About Async Vaults
+### Things to Know About Queued Withdrawal Vaults
 
 - **Withdrawals are not instant** – there is a delay between requesting and receiving your funds, set by the vault's Epoch schedule and the time needed to deallocate from strategies.
 - **Your share price is set at processing, not at request** – the share price applied to your withdrawal is locked in when the Epoch is processed, so your final amount can move up or down between submission and settlement.
@@ -61,7 +61,7 @@ If requests in a given Epoch exceed the cap, the queue processes them in the ord
 - **Requests can roll into the next Epoch** – when an Epoch hits the cap or processing is delayed, the remainder of a request can move to the next Epoch.
 - **Each vault sets minimum and maximum withdrawal sizes** – your request must fall within these limits.
 
-## Pre-Deposit (Cross-Chain) Vault
+## Pre-deposit (Cross Chain) Vault
 
 Some Concrete vaults are pre-deposit vaults, designed for launches where you deposit on one chain and receive shares on another. These do not use the Withdrawal Queue; instead, you claim your shares on the destination chain when the vault is ready.
 

--- a/src/02-Using-Concrete-Vaults/withdraw.md
+++ b/src/02-Using-Concrete-Vaults/withdraw.md
@@ -1,69 +1,65 @@
 ---
 title: "Withdraw"
-description: "Withdrawal documentation for Concrete vaults, covering vault types, the Withdrawal Queue, epoch cadence, and withdrawal caps."
+description: "Withdrawal documentation for Concrete vaults, covering vault types, the Withdrawal Queue, Epoch cadence, and withdrawal caps."
 sidebar_label: "Withdraw"
 ---
 
-Withdrawal behavior depends on the vault. Most Concrete Earn vaults are async vaults: you submit a withdrawal request, the vault groups requests into epochs, processes them on a schedule, and makes the funds available to claim from the **Portfolio** tab. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
+Withdrawal behavior depends on the vault. Most Concrete vaults are async vaults: you submit a withdrawal request, the vault groups requests into Epochs, processes them on a schedule, and makes the funds available to claim from the **Portfolio** tab. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
 
 ## Vault Types and Withdrawal Behavior
 
-Concrete Earn ships two vault implementations and one launch-time variant, each with different withdrawal behavior:
+Concrete ships two vault implementations and one launch-time variant, each with different withdrawal behavior:
 
-- **Async vault** – settles withdrawals through the **Withdrawal Queue**. Used whenever the strategy cannot return assets atomically, for example positions held in a multi-sig wallet for off-chain or multi-venue execution, Pendle LP unwinds, or money markets with withdrawal cooldowns. This is the most common configuration on Concrete.
-- **Standard (atomic) vault** – `withdraw()` and `redeem()` execute in a single transaction. Used when the underlying strategy can return assets immediately.
+- **Atomic vault** – `withdraw()` and `redeem()` execute in a single transaction. Used when the underlying strategy can return assets immediately. Withdrawn assets are returned to the depositor instantly.
+- **Async vault** – settles withdrawals through the **Withdrawal Queue**. Used whenever the strategy cannot return assets atomically, for example positions held in a multi-sig wallet for off-chain or multi-venue execution, Pendle LP unwinds, or money markets with withdrawal cooldowns. A depositor submits a withdrawal request and waits in the queue for a predefined period. This is the most common configuration on Concrete.
 - **Pre-deposit vault** – accepts deposits on one chain before the target vault launches on another. Exit is via a cross-chain share claim, not the Withdrawal Queue. See [Pre-Deposit (Cross-Chain) Vault](#pre-deposit-cross-chain-vault) below.
+
+## Atomic Vault
+
+An atomic vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
+
+1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet.
+2. **The vault settles.** The vault deallocates from strategies in its configured order to cover the withdrawal.
+3. **Receive your assets.** Your shares are burned and the underlying asset is transferred to your wallet in the same transaction.
 
 ## Async Vault (Withdrawal Queue)
 
-1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet. Your ct[Asset] shares are held by the vault and the request joins the current epoch.
-2. **The cutoff passes.** At the vault's scheduled cutoff, the epoch closes to new requests. You can cancel up to the cutoff; once it passes, the request is locked in and a new epoch opens.
-3. **The epoch is processed.** Shortly after the cutoff:
-   - The share price for the epoch is locked in at that moment, not at request time.
+1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet. Your ct[Asset] shares are held by the vault and the request joins the current Epoch.
+2. **The cutoff passes.** At the vault's scheduled cutoff, the Epoch closes to new requests. You can cancel up to the cutoff; once it passes, the request is locked in and a new Epoch opens.
+3. **The Epoch is processed.** Shortly after the cutoff:
+   - The share price for the Epoch is locked in at that moment, not at request time.
    - Your shares are burned.
    - Your assets are reserved for you to claim. They come from the vault's unallocated balance first (idle deposits and previous unwind leftovers); if that is not enough, the **Allocator** deallocates from strategies to cover the difference.
-4. **Claim your assets.** Your withdrawal status moves to **Available** in the Portfolio tab. Click Claim, confirm in your wallet, and the assets arrive in your wallet. If you have multiple withdrawals ready across different epochs, you can claim them together.
+4. **Claim your assets.** Your withdrawal status moves to **Available** in the Portfolio tab. Click Claim, confirm in your wallet, and the assets arrive in your wallet. If you have multiple withdrawals ready across different Epochs, you can claim them together.
 
 You can track each request in the **Portfolio** tab with status labels **Queued**, **Processing**, and **Available**. The app shows an **estimated withdrawal time** based on the vault's cadence and queue depth.
 
 ### Withdrawal Caps Per Epoch
 
-Some vaults set a withdrawal cap that limits the total volume of redemptions processed in a single epoch, expressed as a percentage of vault TVL. Whether a cap is enabled, and at what threshold, is set by the vault curator based on the strategy's liquidity profile and unwind capacity. Not all vaults use caps. Caps work alongside cadence to keep epoch sizes aligned with the strategy's unwind capacity.
+Some vaults set a withdrawal cap that limits the total volume of redemptions processed in a single Epoch, expressed as a percentage of vault TVL. Whether a cap is enabled, and at what threshold, is decided per vault based on the strategy's liquidity profile and unwind capacity. Not all vaults use caps. Caps work alongside cadence to keep Epoch sizes aligned with the strategy's unwind capacity.
 
-To check the exact redemption process, including whether a cap is active and at what threshold, visit the withdrawal management page for the vault.
+To check the exact redemption process, including whether a cap is active and at what threshold, visit the specific vault's page.
 
 **How caps behave**
 
-When requests in an epoch stay under the cap, the epoch processes normally at the scheduled time. When requests exceed the cap, only requests up to the cap threshold are processed in that epoch. The remainder roll forward to subsequent epochs and are processed in the order they were originally requested (First In, First Out). Depositors waiting across multiple epochs continue earning yield until their portion is processed.
+When requests in an Epoch stay under the cap, the Epoch processes normally at the scheduled time. When requests exceed the cap, only requests up to the cap threshold are processed in that Epoch. The remainder roll forward to subsequent Epochs and are processed in the order they were originally requested (First In, First Out). Depositors waiting across multiple Epochs continue earning yield until their portion is processed.
 
 :::info[Example: weekly vault with withdrawal cap]
-Say a vault processes withdrawals every Tuesday with a cap of 20% of TVL per epoch.
+Say a vault processes withdrawals every Tuesday with a cap of 20% of TVL per Epoch.
 
-If Alice submits a withdrawal request on Friday, May 29, her request joins the queue for the next epoch on Tuesday, June 3. If total requests that week are under the 20% cap, Alice receives her funds by Friday, June 6.
+If Alice submits a withdrawal request on Friday, May 29, her request joins the queue for the next Epoch on Tuesday, June 3. If total requests that week are under the 20% cap, Alice receives her funds by Friday, June 6.
 
-If requests in a given epoch exceed the cap, the queue processes them in the order they were submitted (FIFO) across subsequent epochs. Alice continues earning yield on her position while she waits, and her funds are returned as her place in the queue is reached.
+If requests in a given Epoch exceed the cap, the queue processes them in the order they were submitted (FIFO) across subsequent Epochs. Alice continues earning yield on her position while she waits, and her funds are returned as her place in the queue is reached.
 :::
-
-### Cadence of Epochs
-
-Different vaults run on different epoch schedules, which determines how often withdrawals are processed. The default cadence is one epoch per week. The Concrete DeFi USDT vault runs two epochs per week, so under normal load its queue settles within 3.5 to 7 days; if requests exceed the vault's withdrawal cap, the queue extends until later epochs settle the remainder. Each vault's page lists its specific schedule.
 
 ### Things to Know About Async Vaults
 
-- **Withdrawals are not instant** – there is a delay between requesting and receiving your funds, set by the vault's epoch schedule and the time needed to deallocate from strategies.
-- **Your share price is set at processing, not at request** – the share price applied to your withdrawal is locked in when the epoch is processed, so your final amount can move up or down between submission and settlement.
-- **You keep your position until the epoch is processed** – your shares sit with the vault and are not burned until processing happens.
-- **You can cancel, but only before the cutoff** – once the epoch closes, the request is locked in and cannot be cancelled.
-- **Requests can roll into the next epoch** – when an epoch hits the cap or processing is delayed, the **Withdrawal Manager** can move a request to the next epoch.
-- **Each vault sets minimum and maximum withdrawal sizes** – your request must fall within these limits. Some vaults can also pause new withdrawal requests entirely.
-
-## Standard (Atomic) Vault
-
-A standard vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
-
-1. On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet.
-2. The vault deallocates from strategies in its configured order to cover the withdrawal.
-3. Your shares are burned and the underlying asset is transferred to your wallet in the same transaction.
+- **Withdrawals are not instant** – there is a delay between requesting and receiving your funds, set by the vault's Epoch schedule and the time needed to deallocate from strategies.
+- **Your share price is set at processing, not at request** – the share price applied to your withdrawal is locked in when the Epoch is processed, so your final amount can move up or down between submission and settlement.
+- **You keep your position until the Epoch is processed** – your shares sit with the vault and are not burned until processing happens.
+- **You can cancel, but only before the cutoff** – once the Epoch closes, the request is locked in and cannot be cancelled.
+- **Requests can roll into the next Epoch** – when an Epoch hits the cap or processing is delayed, the remainder of a request can move to the next Epoch.
+- **Each vault sets minimum and maximum withdrawal sizes** – your request must fall within these limits.
 
 ## Pre-Deposit (Cross-Chain) Vault
 
@@ -80,6 +76,6 @@ When a pre-deposit vault enters its claim phase, the vault page in the Concrete 
 
 ## Frequently Asked Questions
 
-- **Do my shares continue earning yield while in the queue?** Shares are held by the vault and are not burned until `processEpoch()` runs. Share price is locked at processing time, so any yield (or loss) the vault records between request and processing is reflected in the price applied to the request.
-- **Can I cancel a withdrawal request?** Yes, for the current open epoch only, you can cancel on the vault page. Once the cutoff passes, the request cannot be cancelled.
-- **What happens if my request cannot be filled in its epoch?** When the epoch reaches its withdrawal cap or processing is delayed, the **Withdrawal Manager** moves the remainder to the next epoch via `moveRequestToNextEpoch()`. Your queue position is preserved (FIFO).
+- **Do my shares continue earning yield while in the queue?** Shares are held by the vault and are not burned until the Epoch is processed. Share price is locked at processing time, so any yield (or loss) the vault records between request and processing is reflected in the price applied to the request.
+- **Can I cancel a withdrawal request?** Yes, for the current open Epoch only, you can cancel on the vault page. Once the cutoff passes, the request cannot be cancelled.
+- **What happens if my request cannot be filled in its Epoch?** When the Epoch reaches its withdrawal cap, the remainder of your withdrawal request is moved to the next Epoch. Your queue position is preserved (FIFO).

--- a/src/02-Using-Concrete-Vaults/withdraw.md
+++ b/src/02-Using-Concrete-Vaults/withdraw.md
@@ -10,13 +10,13 @@ Withdrawal behavior depends on the vault. Most Concrete vaults are Queued Withdr
 
 Concrete ships two vault implementations and one launch-time variant, each with different withdrawal behavior:
 
-- **Standard (Atomic) Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
-- **Queued Withdrawal Vault** – Adds an Epoch-based withdrawal queue to the Standard vault, where requests are collected during an Epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
-- **Pre-deposit (Cross Chain) Vault** – Extends the Standard vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch. See [Pre-deposit (Cross Chain) Vault](#pre-deposit-cross-chain-vault) below.
+- **Atomic Vault** – The base implementation; deposits and withdrawals execute in a single transaction. It suits vaults where strategy liquidity is always available on-chain and can be unwound atomically.
+- **Queued Withdrawal Vault** – Adds an Epoch-based withdrawal queue to the Atomic vault, where requests are collected during an Epoch, processed at a scheduled point that locks a share price and reserves assets, then claimed by users. Toggled on or off by the Vault Manager, it is the most common production configuration and suits strategies with off-chain custody.
+- **Pre-deposit (Cross Chain) Vault** – Extends the Atomic vault for cross-chain launches: users deposit on a source chain, the vault locks, assets bridge to a target chain, and users claim shares there via LayerZero messaging. This phase-specific type is typically succeeded by a Queued Withdrawal Vault on the target chain after launch. See [Pre-deposit (Cross Chain) Vault](#pre-deposit-cross-chain-vault) below.
 
-## Standard (Atomic) Vault
+## Atomic Vault
 
-A Standard (Atomic) Vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
+An Atomic Vault returns assets in a single transaction. `withdraw()` and `redeem()` deallocate from strategies in the vault's configured deallocation order, burn your shares, and transfer the underlying asset to your wallet in one call.
 
 1. **Submit your request.** On the vault page, open the Withdraw tab, enter the amount, and confirm in your wallet.
 2. **The vault settles.** The vault deallocates from strategies in its configured order to cover the withdrawal.

--- a/src/02-Using-Concrete-Vaults/withdraw.md
+++ b/src/02-Using-Concrete-Vaults/withdraw.md
@@ -4,7 +4,7 @@ description: "Withdrawal documentation for Concrete vaults, covering vault types
 sidebar_label: "Withdraw"
 ---
 
-Withdrawal behavior depends on the vault. Most Concrete vaults are async vaults: you submit a withdrawal request, the vault groups requests into Epochs, processes them on a schedule, and makes the funds available to claim from the **Portfolio** tab. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
+Withdrawal behavior depends on the vault. Most Concrete vaults are async vaults: you submit a withdrawal request, the vault groups requests into Epochs, processes them on a schedule, and makes the funds available to claim from the vault page. Other vaults settle atomically, and pre-deposit vaults exit through a cross-chain claim. Each vault's page in the Concrete app states which model it uses.
 
 ## Vault Types and Withdrawal Behavior
 
@@ -30,9 +30,9 @@ An atomic vault returns assets in a single transaction. `withdraw()` and `redeem
    - The share price for the Epoch is locked in at that moment, not at request time.
    - Your shares are burned.
    - Your assets are reserved for you to claim. They come from the vault's unallocated balance first (idle deposits and previous unwind leftovers); if that is not enough, the **Allocator** deallocates from strategies to cover the difference.
-4. **Claim your assets.** Your withdrawal status moves to **Available** in the Portfolio tab. Click Claim, confirm in your wallet, and the assets arrive in your wallet. If you have multiple withdrawals ready across different Epochs, you can claim them together.
+4. **Claim your assets.** Your withdrawal status moves to **Available** in the vault page. Click Claim, confirm in your wallet, and the assets arrive in your wallet. If you have multiple withdrawals ready across different Epochs, you can claim them together.
 
-You can track each request in the **Portfolio** tab with status labels **Queued**, **Processing**, and **Available**. The app shows an **estimated withdrawal time** based on the vault's cadence and queue depth.
+You can track each request in the vault page with status labels **Queued**, **Processing**, and **Available**. The app shows an **estimated withdrawal time** based on the vault's cadence and queue depth.
 
 ### Withdrawal Caps Per Epoch
 


### PR DESCRIPTION
## Summary

Follow-up to #117 addressing the 12 unresolved review comments from @kar-mal on `src/05-Vaults/how-withdrawals-work.md` (now `src/02-Using-Concrete-Vaults/withdraw.md` after the IA restructure).

### Changes

- Drop "Earn" from "Concrete Earn vaults" and "Concrete Earn ships two vault implementations" (#117 comments on lines 7, 11).
- Reorder so the **Atomic vault** description appears before the **Async vault** section and drop the "Standard" prefix (line 60).
- Add user-perspective sentences:
  - Atomic: "Withdrawn assets are returned to the depositor instantly." (line 14)
  - Async: "A depositor submits a withdrawal request and waits in the queue for a predefined period." (line 13)
- Rewrite the Atomic vault numbered steps using the same bold-prefix style as Async (line 66).
- Capitalize **Epoch** consistently as a defined term (line 19).
- Replace "set by the vault curator" with "decided per vault" (line 31).
- Replace "withdrawal management page for the vault" with "specific vault's page" (line 33).
- Delete the **Cadence of Epochs** section. Epoch schedule is referenced generically in the Things to Know list and via the vault's own page (line 49).
- Drop the **Withdrawal Manager** term in the rollover bullet (line 57).
- Drop the "Some vaults can also pause new withdrawal requests entirely" line (line 58).
- Rephrase the two FAQ items at the bottom to drop the `processEpoch()` and `moveRequestToNextEpoch()` references (`llms-full.txt` lines 3005 and 3007 in #117; `llms-full.txt` is auto-regenerated from this source).

Stacked on top of #123 (CONC-3738). Will auto-rebase to `main` once #123 merges.