### PR TITLE
docs(earn): withdrawal cooldown

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -19,6 +19,7 @@ const sidebars = {
         'Using-Concrete-Vaults/concrete-vault-shares',
         'Using-Concrete-Vaults/deposit',
         'Using-Concrete-Vaults/withdraw',
+        'Using-Concrete-Vaults/withdrawal-cooldown',
         'Using-Concrete-Vaults/vault-transparency',
         'Using-Concrete-Vaults/bridging-and-depositing-with-enso',
         'Using-Concrete-Vaults/fees',

--- a/src/02-Using-Concrete-Vaults/fees.md
+++ b/src/02-Using-Concrete-Vaults/fees.md
@@ -15,7 +15,7 @@ Fees are paid by minting vault shares to a fee recipient rather than transferrin
 | --- | --- | --- |
 | Deposit fee | None | No fees on deposits. |
 | Withdrawal fee | None | No fees on withdrawals. |
-| Cooldown Exit fee | 0–1% of position | The Withdrawal Cooldown can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
+| Cooldown Exit fee | 0–1% of position | The [Withdrawal Cooldown](/Using-Concrete-Vaults/withdrawal-cooldown/) can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
 | Management fee | 0–10% of position | Annualized charge on vault [AUM](/glossary/#aum), accrued continuously based on time elapsed. Configured per vault, with a standard rate of 1.5% applied to most vaults. See individual vault pages for rates applied to your vault. |
 | Performance fee | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault. See individual vault pages for current rates. |
 | Hurdle rate on Performance fee | 0–30% of net positive yield | Target return (the hurdle) is defined for depositors, and fees apply only to yield generated above that threshold. Yield up to the hurdle is distributed to depositors.<br /><br />**Fixed [APY](/glossary/#apy)** – a constant annualized target that compounds.<br />**Fixed [APR](/glossary/#apr)** – a constant annualized target calculated on a simple (non-compounding) basis.<br />**Dynamic hurdle** – a variable target that adjusts based on external rate. |

--- a/src/02-Using-Concrete-Vaults/withdrawal-cooldown.md
+++ b/src/02-Using-Concrete-Vaults/withdrawal-cooldown.md
@@ -1,0 +1,81 @@
+---
+title: "Withdrawal Cooldown"
+description: "How the Withdrawal Cooldown works on Earn vaults: per-deposit lock periods, the decaying Cooldown Exit fee, and how the cooldown relates to the Withdrawal Queue."
+sidebar_label: "Withdrawal Cooldown"
+---
+
+# Withdrawal Cooldown
+
+Some Earn vaults apply a **Withdrawal Cooldown**: after you deposit, the shares from that deposit stay locked for a configured period. If you withdraw those shares before the period ends, the vault charges a **Cooldown Exit fee** that decays over time. This page explains the mechanism, what you see in the [Concrete app](https://app.concrete.xyz/earn), and how the cooldown relates to the [Withdrawal Queue](/Using-Concrete-Vaults/withdraw/).
+
+Not every vault uses a Withdrawal Cooldown. Whether it applies, its duration, and its maximum bypass fee are configured per vault and shown on that vault's page in the app.
+
+## What the cooldown does
+
+A Withdrawal Cooldown starts when you deposit into a vault that enables it. During the cooldown, the shares from that deposit count as locked. The in-app copy states that a withdrawal cooldown optimises [APY](/glossary/#apy): holding deposits for a known minimum period lets strategies commit capital with more predictable liquidity.
+
+The cooldown applies **per deposit**. Each deposit starts its own cooldown period, so a position built from several deposits can have several active cooldown entries at once.
+
+You can still withdraw before a deposit's cooldown ends. When you do, the vault applies the **Cooldown Exit fee** to the shares that are still locked. The fee decays linearly from its maximum at the start of the cooldown to 0% when the cooldown expires. See [Fees](/Using-Concrete-Vaults/fees/) for the fee type and range.
+
+## Cooldown and the Withdrawal Queue
+
+The Withdrawal Cooldown and the [Withdrawal Queue](/Using-Concrete-Vaults/withdraw/) are separate mechanisms, and both can apply on the same vault.
+
+- **Withdrawal Cooldown** – whether locked shares can be withdrawn without a Cooldown Exit fee.
+- **Withdrawal Queue** – how a withdrawal request is batched into [Epochs](/glossary/#epoch), processed, and made available to claim.
+
+On vaults that use both, the cooldown period is **in addition to** the queue period. The app states this in deposit tooltips, the Withdrawal Cooldown modal, and the Portfolio lock tooltip. After shares pass the cooldown, a queued withdrawal still follows the vault's Epoch schedule described in [Withdraw](/Using-Concrete-Vaults/withdraw/).
+
+## Deposit panel
+
+When a vault uses a Withdrawal Cooldown, the deposit panel on the vault page shows a **Withdrawal Cooldown** row with the configured duration in days.
+
+A tooltip next to the row includes:
+
+- A chart of the fee decay from the vault's maximum Cooldown Exit fee at day 0 to 0% at the end of the cooldown.
+- Copy that a withdrawal cooldown optimises [APY](/glossary/#apy), that the cooldown may be bypassed for a fee, and that the cooldown period is in addition to the withdrawal queue.
+
+If the vault also uses a queued withdrawal model, a **Withdrawal delay** row may appear when queue timing is available. That row describes queue timing, not the cooldown duration itself.
+
+## Withdraw modal breakdown
+
+When you withdraw from a vault with active cooldown entries, a modal titled **Withdrawal Cooldown** lists each deposit that is still in cooldown.
+
+For every active lock, the modal shows three rows:
+
+- **Deposit (date)** – the deposit date and the share amount from that deposit that is still locked, labelled with the vault asset.
+- **Day N fee** – the Cooldown Exit fee percentage that applies to that deposit today. **Day N** counts from day 1 on the deposit date.
+- **Withdrawal cooldown ends** – the date when that deposit's cooldown expires. After this date, no Cooldown Exit fee applies to those shares.
+
+The modal also renders each lock's position on the fee-decay chart. Deposits that have finished their cooldown do not appear in the breakdown.
+
+The footer copy repeats the optimises [APY](/glossary/#apy) explanation, the vault-specific maximum bypass fee, and that the cooldown period is in addition to the withdrawal queue.
+
+:::info
+Deposit dates, locked share amounts, day-N fee percentages, and cooldown end dates are computed from your wallet's on-chain lock state and shown live in the [Concrete app](https://app.concrete.xyz/earn). This page describes the rows; the live values appear in the modal.
+:::
+
+## Portfolio lock indicator
+
+On the **Portfolio** tab, each vault position shows your share balance. When part of your position is still in cooldown, a lock icon appears next to the balance in both the table and card views.
+
+Hovering the lock icon opens a tooltip labelled **Withdrawal Cooldown** with:
+
+- The locked share amount and vault share symbol.
+- Copy that the Withdrawal Cooldown is in addition to the Withdrawal Queue period, with a link to learn more about withdrawals.
+
+The lock icon appears only when your effective locked amount for that vault is greater than zero. When all cooldown entries have expired, the icon is hidden.
+
+## Example
+
+Suppose a vault applies a Withdrawal Cooldown and you deposit on two separate days.
+
+1. On the **Deposit** panel, the **Withdrawal Cooldown** row shows the configured duration. The tooltip explains the fee decay and that the cooldown stacks on top of the queue.
+2. You open **Withdraw**. The **Withdrawal Cooldown** modal lists two breakdown groups, one per deposit still in cooldown, each with deposit date, **Day N fee**, and cooldown end date.
+3. The more recent deposit is earlier in its cooldown, so its **Day N fee** is higher than the older deposit's.
+4. If you withdraw while a deposit is still in cooldown, the vault applies the fee shown for that deposit. If you wait until its cooldown ends, that deposit drops out of the breakdown and no Cooldown Exit fee applies to it.
+5. On a queued vault, the withdrawal request then settles through the [Withdrawal Queue](/Using-Concrete-Vaults/withdraw/) as usual.
+6. On **Portfolio**, a lock icon appears next to your position while any shares remain locked. The tooltip shows how much is locked under **Withdrawal Cooldown**.
+
+For contract-level detail on deposit-lock hooks, see [Architecture core concepts](/Developers/architecture-core-concepts/).

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Concrete Docs - LLM Full Context
 
-Generated: 2026-06-12T10:01:29.312Z
+Generated: 2026-06-15T12:01:48.146Z
 Source repository: concrete-docs
 Canonical docs URL: https://docs.concrete.xyz/
 
@@ -13,59 +13,60 @@ This file consolidates every Markdown documentation page in `src/**/*.md` for re
 3. Concrete Vault Shares [sidebar] - src/02-Using-Concrete-Vaults/concrete-vault-shares.md
 4. Deposit [sidebar] - src/02-Using-Concrete-Vaults/deposit.md
 5. Withdraw [sidebar] - src/02-Using-Concrete-Vaults/withdraw.md
-6. Vault Transparency [sidebar] - src/02-Using-Concrete-Vaults/vault-transparency.md
-7. Bridging and Depositing with Enso [sidebar] - src/02-Using-Concrete-Vaults/bridging-and-depositing-with-enso.md
-8. Fees [sidebar] - src/02-Using-Concrete-Vaults/fees.md
-9. Concrete Points Program [sidebar] - src/02-Using-Concrete-Vaults/concrete-points.md
-10. Architecture: Core Concepts [sidebar] - src/03-Developers/architecture-core-concepts.md
-11. Overview [sidebar] - src/03-Developers/SDK/overview.md
-12. Setup Configuration [sidebar] - src/03-Developers/SDK/setup-configuration.md
-13. balanceOf(address) [sidebar] - src/03-Developers/SDK/read-methods/balanceOf.md
-14. getAddress() [sidebar] - src/03-Developers/SDK/read-methods/getAddress.md
-15. getUnderlyingDecimals() [sidebar] - src/03-Developers/SDK/read-methods/getUnderlyingDecimals.md
-16. getVaultDetails() [sidebar] - src/03-Developers/SDK/read-methods/getVaultDetails.md
-17. getVaultTransparencyStats (API) [sidebar] - src/03-Developers/SDK/read-methods/getVaultTransparencyStats.md
-18. getAllWithdrawQueueRequests(owner) [sidebar] - src/03-Developers/SDK/read-methods/getAllWithdrawQueueRequests.md
-19. previewConversion(amount) [sidebar] - src/03-Developers/SDK/read-methods/previewConversion.md
-20. totalAssets() [sidebar] - src/03-Developers/SDK/read-methods/totalAssets.md
-21. symbol() [sidebar] - src/03-Developers/SDK/read-methods/symbol.md
-22. decimals() [sidebar] - src/03-Developers/SDK/read-methods/decimals.md
-23. applyDecimals(amount) [sidebar] - src/03-Developers/SDK/read-methods/applyDecimals.md
-24. toUnderlyingDecimals(amount) [sidebar] - src/03-Developers/SDK/read-methods/toUnderlyingDecimals.md
-25. approve(spender, amount) [sidebar] - src/03-Developers/SDK/write-methods/approve.md
-26. deposit(amount) [sidebar] - src/03-Developers/SDK/write-methods/deposit.md
-27. redeem(amount) [sidebar] - src/03-Developers/SDK/write-methods/redeem.md
-28. transfer(to, amount) [sidebar] - src/03-Developers/SDK/write-methods/transfer.md
-29. transferFrom(from, to, amount) [sidebar] - src/03-Developers/SDK/write-methods/transferFrom.md
-30. Decimals & Conversion Helpers [sidebar] - src/03-Developers/SDK/decimals-and-conversion-helpers.md
-31. Examples [sidebar] - src/03-Developers/SDK/examples.md
-32. Troubleshooting & Error Handling [sidebar] - src/03-Developers/SDK/troubleshooting-and-error-handling.md
-33. Schema & Queries [sidebar] - src/03-Developers/Subgraph-and-Events/schema-and-queries.md
-34. Event Reference [sidebar] - src/03-Developers/Subgraph-and-Events/event-reference-and-use-cases.md
-35. How Withdrawals Are Processed For Concrete DeFi USDT [sidebar] - src/04-Live-Vaults/DeFi-USDT/how-withdrawals-are-processed.md
-36. Important Disclosures [sidebar] - src/04-Live-Vaults/DeFi-USDT/important-disclosures.md
-37. WBTC Vault [sidebar] - src/04-Live-Vaults/wbtc-vault.md
-38. Overview [sidebar] - src/05-Completed-Campaigns/overview.md
-39. Bera [sidebar] - src/05-Completed-Campaigns/bera.md
-40. Stable [sidebar] - src/05-Completed-Campaigns/stable.md
-41. Corn [sidebar] - src/05-Completed-Campaigns/corn.md
-42. Morph [sidebar] - src/05-Completed-Campaigns/morph.md
-43. TAC [sidebar] - src/05-Completed-Campaigns/tac.md
-44. Pre-Deposit Campaigns [sidebar] - src/05-Completed-Campaigns/pre-deposit-campaigns.md
-45. Audits [sidebar] - src/06-Audits.md
-46. Risks and Safety [sidebar] - src/07-risks-and-safety.md
-47. Restricted Jurisdictions [sidebar] - src/08-restricted-jurisdictions.md
-48. Glossary [sidebar] - src/glossary.md
-49. Support [sidebar] - src/support.md
-50. How to Repay and Withdraw Borrowed Assets [unlisted] - src/03-Borrow/close-loan.md
-51. How to Activate Concrete Borrow (Default Lite) [unlisted] - src/03-Borrow/enable-concrete.md
-52. How to Borrow From External Market [unlisted] - src/03-Borrow/open-loan-externally.md
-53. How to Borrow Against Collateral [unlisted] - src/03-Borrow/open-loan.md
-54. Overview [unlisted] - src/03-Borrow/overview.md
-55. Quick Start (Plug-and-Play Integration) [unlisted] - src/03-Developers/SDK/quick-start.md
-56. getApyDetails() [unlisted] - src/03-Developers/SDK/read-methods/getAPYDetails.md
-57. How to Activate Concrete Protect [unlisted] - src/04-Protect/activate-concrete-protect.md
-58. Overview [unlisted] - src/04-Protect/overview.md
+6. Withdrawal Cooldown [sidebar] - src/02-Using-Concrete-Vaults/withdrawal-cooldown.md
+7. Vault Transparency [sidebar] - src/02-Using-Concrete-Vaults/vault-transparency.md
+8. Bridging and Depositing with Enso [sidebar] - src/02-Using-Concrete-Vaults/bridging-and-depositing-with-enso.md
+9. Fees [sidebar] - src/02-Using-Concrete-Vaults/fees.md
+10. Concrete Points Program [sidebar] - src/02-Using-Concrete-Vaults/concrete-points.md
+11. Architecture: Core Concepts [sidebar] - src/03-Developers/architecture-core-concepts.md
+12. Overview [sidebar] - src/03-Developers/SDK/overview.md
+13. Setup Configuration [sidebar] - src/03-Developers/SDK/setup-configuration.md
+14. balanceOf(address) [sidebar] - src/03-Developers/SDK/read-methods/balanceOf.md
+15. getAddress() [sidebar] - src/03-Developers/SDK/read-methods/getAddress.md
+16. getUnderlyingDecimals() [sidebar] - src/03-Developers/SDK/read-methods/getUnderlyingDecimals.md
+17. getVaultDetails() [sidebar] - src/03-Developers/SDK/read-methods/getVaultDetails.md
+18. getVaultTransparencyStats (API) [sidebar] - src/03-Developers/SDK/read-methods/getVaultTransparencyStats.md
+19. getAllWithdrawQueueRequests(owner) [sidebar] - src/03-Developers/SDK/read-methods/getAllWithdrawQueueRequests.md
+20. previewConversion(amount) [sidebar] - src/03-Developers/SDK/read-methods/previewConversion.md
+21. totalAssets() [sidebar] - src/03-Developers/SDK/read-methods/totalAssets.md
+22. symbol() [sidebar] - src/03-Developers/SDK/read-methods/symbol.md
+23. decimals() [sidebar] - src/03-Developers/SDK/read-methods/decimals.md
+24. applyDecimals(amount) [sidebar] - src/03-Developers/SDK/read-methods/applyDecimals.md
+25. toUnderlyingDecimals(amount) [sidebar] - src/03-Developers/SDK/read-methods/toUnderlyingDecimals.md
+26. approve(spender, amount) [sidebar] - src/03-Developers/SDK/write-methods/approve.md
+27. deposit(amount) [sidebar] - src/03-Developers/SDK/write-methods/deposit.md
+28. redeem(amount) [sidebar] - src/03-Developers/SDK/write-methods/redeem.md
+29. transfer(to, amount) [sidebar] - src/03-Developers/SDK/write-methods/transfer.md
+30. transferFrom(from, to, amount) [sidebar] - src/03-Developers/SDK/write-methods/transferFrom.md
+31. Decimals & Conversion Helpers [sidebar] - src/03-Developers/SDK/decimals-and-conversion-helpers.md
+32. Examples [sidebar] - src/03-Developers/SDK/examples.md
+33. Troubleshooting & Error Handling [sidebar] - src/03-Developers/SDK/troubleshooting-and-error-handling.md
+34. Schema & Queries [sidebar] - src/03-Developers/Subgraph-and-Events/schema-and-queries.md
+35. Event Reference [sidebar] - src/03-Developers/Subgraph-and-Events/event-reference-and-use-cases.md
+36. How Withdrawals Are Processed For Concrete DeFi USDT [sidebar] - src/04-Live-Vaults/DeFi-USDT/how-withdrawals-are-processed.md
+37. Important Disclosures [sidebar] - src/04-Live-Vaults/DeFi-USDT/important-disclosures.md
+38. WBTC Vault [sidebar] - src/04-Live-Vaults/wbtc-vault.md
+39. Overview [sidebar] - src/05-Completed-Campaigns/overview.md
+40. Bera [sidebar] - src/05-Completed-Campaigns/bera.md
+41. Stable [sidebar] - src/05-Completed-Campaigns/stable.md
+42. Corn [sidebar] - src/05-Completed-Campaigns/corn.md
+43. Morph [sidebar] - src/05-Completed-Campaigns/morph.md
+44. TAC [sidebar] - src/05-Completed-Campaigns/tac.md
+45. Pre-Deposit Campaigns [sidebar] - src/05-Completed-Campaigns/pre-deposit-campaigns.md
+46. Audits [sidebar] - src/06-Audits.md
+47. Risks and Safety [sidebar] - src/07-risks-and-safety.md
+48. Restricted Jurisdictions [sidebar] - src/08-restricted-jurisdictions.md
+49. Glossary [sidebar] - src/glossary.md
+50. Support [sidebar] - src/support.md
+51. How to Repay and Withdraw Borrowed Assets [unlisted] - src/03-Borrow/close-loan.md
+52. How to Activate Concrete Borrow (Default Lite) [unlisted] - src/03-Borrow/enable-concrete.md
+53. How to Borrow From External Market [unlisted] - src/03-Borrow/open-loan-externally.md
+54. How to Borrow Against Collateral [unlisted] - src/03-Borrow/open-loan.md
+55. Overview [unlisted] - src/03-Borrow/overview.md
+56. Quick Start (Plug-and-Play Integration) [unlisted] - src/03-Developers/SDK/quick-start.md
+57. getApyDetails() [unlisted] - src/03-Developers/SDK/read-methods/getAPYDetails.md
+58. How to Activate Concrete Protect [unlisted] - src/04-Protect/activate-concrete-protect.md
+59. Overview [unlisted] - src/04-Protect/overview.md
 
 # Document 1: Concrete: Earn Yield on Supported On-Chain Assets
 Source: src/01-Overview/welcome.md
@@ -333,7 +334,91 @@ When a pre-deposit vault enters its claim phase, the vault page in the Concrete 
 
 ---
 
-# Document 6: Vault Transparency
+# Document 6: Withdrawal Cooldown
+Source: src/02-Using-Concrete-Vaults/withdrawal-cooldown.md
+Doc ID: Using-Concrete-Vaults/withdrawal-cooldown
+Public URL: https://docs.concrete.xyz/Using-Concrete-Vaults/withdrawal-cooldown/
+In active sidebar: yes
+Description: How the Withdrawal Cooldown works on Earn vaults: per-deposit lock periods, the decaying Cooldown Exit fee, and how the cooldown relates to the Withdrawal Queue.
+# Withdrawal Cooldown
+
+Some Earn vaults apply a **Withdrawal Cooldown**: after you deposit, the shares from that deposit stay locked for a configured period. If you withdraw those shares before the period ends, the vault charges a **Cooldown Exit fee** that decays over time. This page explains the mechanism, what you see in the [Concrete app](https://app.concrete.xyz/earn), and how the cooldown relates to the [Withdrawal Queue](https://docs.concrete.xyz/Using-Concrete-Vaults/withdraw/).
+
+Not every vault uses a Withdrawal Cooldown. Whether it applies, its duration, and its maximum bypass fee are configured per vault and shown on that vault's page in the app.
+
+## What the cooldown does
+
+A Withdrawal Cooldown starts when you deposit into a vault that enables it. During the cooldown, the shares from that deposit count as locked. The in-app copy states that a withdrawal cooldown optimises [APY](https://docs.concrete.xyz/glossary/#apy): holding deposits for a known minimum period lets strategies commit capital with more predictable liquidity.
+
+The cooldown applies **per deposit**. Each deposit starts its own cooldown period, so a position built from several deposits can have several active cooldown entries at once.
+
+You can still withdraw before a deposit's cooldown ends. When you do, the vault applies the **Cooldown Exit fee** to the shares that are still locked. The fee decays linearly from its maximum at the start of the cooldown to 0% when the cooldown expires. See [Fees](https://docs.concrete.xyz/Using-Concrete-Vaults/fees/) for the fee type and range.
+
+## Cooldown and the Withdrawal Queue
+
+The Withdrawal Cooldown and the [Withdrawal Queue](https://docs.concrete.xyz/Using-Concrete-Vaults/withdraw/) are separate mechanisms, and both can apply on the same vault.
+
+- **Withdrawal Cooldown** – whether locked shares can be withdrawn without a Cooldown Exit fee.
+- **Withdrawal Queue** – how a withdrawal request is batched into [Epochs](https://docs.concrete.xyz/glossary/#epoch), processed, and made available to claim.
+
+On vaults that use both, the cooldown period is **in addition to** the queue period. The app states this in deposit tooltips, the Withdrawal Cooldown modal, and the Portfolio lock tooltip. After shares pass the cooldown, a queued withdrawal still follows the vault's Epoch schedule described in [Withdraw](https://docs.concrete.xyz/Using-Concrete-Vaults/withdraw/).
+
+## Deposit panel
+
+When a vault uses a Withdrawal Cooldown, the deposit panel on the vault page shows a **Withdrawal Cooldown** row with the configured duration in days.
+
+A tooltip next to the row includes:
+
+- A chart of the fee decay from the vault's maximum Cooldown Exit fee at day 0 to 0% at the end of the cooldown.
+- Copy that a withdrawal cooldown optimises [APY](https://docs.concrete.xyz/glossary/#apy), that the cooldown may be bypassed for a fee, and that the cooldown period is in addition to the withdrawal queue.
+
+If the vault also uses a queued withdrawal model, a **Withdrawal delay** row may appear when queue timing is available. That row describes queue timing, not the cooldown duration itself.
+
+## Withdraw modal breakdown
+
+When you withdraw from a vault with active cooldown entries, a modal titled **Withdrawal Cooldown** lists each deposit that is still in cooldown.
+
+For every active lock, the modal shows three rows:
+
+- **Deposit (date)** – the deposit date and the share amount from that deposit that is still locked, labelled with the vault asset.
+- **Day N fee** – the Cooldown Exit fee percentage that applies to that deposit today. **Day N** counts from day 1 on the deposit date.
+- **Withdrawal cooldown ends** – the date when that deposit's cooldown expires. After this date, no Cooldown Exit fee applies to those shares.
+
+The modal also renders each lock's position on the fee-decay chart. Deposits that have finished their cooldown do not appear in the breakdown.
+
+The footer copy repeats the optimises [APY](https://docs.concrete.xyz/glossary/#apy) explanation, the vault-specific maximum bypass fee, and that the cooldown period is in addition to the withdrawal queue.
+
+:::info
+Deposit dates, locked share amounts, day-N fee percentages, and cooldown end dates are computed from your wallet's on-chain lock state and shown live in the [Concrete app](https://app.concrete.xyz/earn). This page describes the rows; the live values appear in the modal.
+:::
+
+## Portfolio lock indicator
+
+On the **Portfolio** tab, each vault position shows your share balance. When part of your position is still in cooldown, a lock icon appears next to the balance in both the table and card views.
+
+Hovering the lock icon opens a tooltip labelled **Withdrawal Cooldown** with:
+
+- The locked share amount and vault share symbol.
+- Copy that the Withdrawal Cooldown is in addition to the Withdrawal Queue period, with a link to learn more about withdrawals.
+
+The lock icon appears only when your effective locked amount for that vault is greater than zero. When all cooldown entries have expired, the icon is hidden.
+
+## Example
+
+Suppose a vault applies a Withdrawal Cooldown and you deposit on two separate days.
+
+1. On the **Deposit** panel, the **Withdrawal Cooldown** row shows the configured duration. The tooltip explains the fee decay and that the cooldown stacks on top of the queue.
+2. You open **Withdraw**. The **Withdrawal Cooldown** modal lists two breakdown groups, one per deposit still in cooldown, each with deposit date, **Day N fee**, and cooldown end date.
+3. The more recent deposit is earlier in its cooldown, so its **Day N fee** is higher than the older deposit's.
+4. If you withdraw while a deposit is still in cooldown, the vault applies the fee shown for that deposit. If you wait until its cooldown ends, that deposit drops out of the breakdown and no Cooldown Exit fee applies to it.
+5. On a queued vault, the withdrawal request then settles through the [Withdrawal Queue](https://docs.concrete.xyz/Using-Concrete-Vaults/withdraw/) as usual.
+6. On **Portfolio**, a lock icon appears next to your position while any shares remain locked. The tooltip shows how much is locked under **Withdrawal Cooldown**.
+
+For contract-level detail on deposit-lock hooks, see [Architecture core concepts](https://docs.concrete.xyz/Developers/architecture-core-concepts/).
+
+---
+
+# Document 7: Vault Transparency
 Source: src/02-Using-Concrete-Vaults/vault-transparency.md
 Doc ID: Using-Concrete-Vaults/vault-transparency
 Public URL: https://docs.concrete.xyz/Using-Concrete-Vaults/vault-transparency/
@@ -381,7 +466,7 @@ For the full request and response reference, see [Vault transparency stats (API)
 
 ---
 
-# Document 7: Bridging and Depositing with Enso
+# Document 8: Bridging and Depositing with Enso
 Source: src/02-Using-Concrete-Vaults/bridging-and-depositing-with-enso.md
 Doc ID: Using-Concrete-Vaults/bridging-and-depositing-with-enso
 Public URL: https://docs.concrete.xyz/Using-Concrete-Vaults/bridging-and-depositing-with-enso/
@@ -444,7 +529,7 @@ If you run into any issues depositing into a vault:
 
 ---
 
-# Document 8: Fees
+# Document 9: Fees
 Source: src/02-Using-Concrete-Vaults/fees.md
 Doc ID: Using-Concrete-Vaults/fees
 Public URL: https://docs.concrete.xyz/Using-Concrete-Vaults/fees/
@@ -460,7 +545,7 @@ Fees are paid by minting vault shares to a fee recipient rather than transferrin
 | --- | --- | --- |
 | Deposit fee | None | No fees on deposits. |
 | Withdrawal fee | None | No fees on withdrawals. |
-| Cooldown Exit fee | 0–1% of position | The Withdrawal Cooldown can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
+| Cooldown Exit fee | 0–1% of position | The [Withdrawal Cooldown](https://docs.concrete.xyz/Using-Concrete-Vaults/withdrawal-cooldown/) can be bypassed for a fee. Fee size decays linearly as Cooldown approaches the expiry date. |
 | Management fee | 0–10% of position | Annualized charge on vault [AUM](https://docs.concrete.xyz/glossary/#aum), accrued continuously based on time elapsed. Configured per vault, with a standard rate of 1.5% applied to most vaults. See individual vault pages for rates applied to your vault. |
 | Performance fee | 0–30% of net positive yield | Charged only when strategies produce net gains after losses at the time of yield accrual. Configured per vault. See individual vault pages for current rates. |
 | Hurdle rate on Performance fee | 0–30% of net positive yield | Target return (the hurdle) is defined for depositors, and fees apply only to yield generated above that threshold. Yield up to the hurdle is distributed to depositors.<br /><br />**Fixed [APY](https://docs.concrete.xyz/glossary/#apy)** – a constant annualized target that compounds.<br />**Fixed [APR](https://docs.concrete.xyz/glossary/#apr)** – a constant annualized target calculated on a simple (non-compounding) basis.<br />**Dynamic hurdle** – a variable target that adjusts based on external rate. |
@@ -479,7 +564,7 @@ Fees are calculated as part of the vault's yield accrual process, in this order:
 
 ---
 
-# Document 9: Concrete Points Program
+# Document 10: Concrete Points Program
 Source: src/02-Using-Concrete-Vaults/concrete-points.md
 Doc ID: Using-Concrete-Vaults/concrete-points
 Public URL: https://docs.concrete.xyz/Using-Concrete-Vaults/concrete-points/
@@ -539,7 +624,7 @@ If you have questions about the campaign or how to participate, please refer to 
 
 ---
 
-# Document 10: Architecture: Core Concepts
+# Document 11: Architecture: Core Concepts
 Source: src/03-Developers/architecture-core-concepts.md
 Doc ID: Developers/architecture-core-concepts
 Public URL: https://docs.concrete.xyz/Developers/architecture-core-concepts/
@@ -659,7 +744,7 @@ Concrete's smart-contract source is held in a private repository. Partners and i
 
 ---
 
-# Document 11: Overview
+# Document 12: Overview
 Source: src/03-Developers/SDK/overview.md
 Doc ID: Developers/SDK/overview
 Public URL: https://docs.concrete.xyz/Developers/SDK/overview/
@@ -761,7 +846,7 @@ await redeemTx.wait();
 
 ---
 
-# Document 12: Setup Configuration
+# Document 13: Setup Configuration
 Source: src/03-Developers/SDK/setup-configuration.md
 Doc ID: Developers/SDK/setup-configuration
 Public URL: https://docs.concrete.xyz/Developers/SDK/setup-configuration/
@@ -898,7 +983,7 @@ function VaultInfo() {
 
 ---
 
-# Document 13: balanceOf(address)
+# Document 14: balanceOf(address)
 Source: src/03-Developers/SDK/read-methods/balanceOf.md
 Doc ID: Developers/SDK/read-methods/balanceOf
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/balanceOf/
@@ -948,7 +1033,7 @@ console.log("Underlying (from human):", await vault.toUnderlyingBigInt("1.0"));
 
 ---
 
-# Document 14: getAddress()
+# Document 15: getAddress()
 Source: src/03-Developers/SDK/read-methods/getAddress.md
 Doc ID: Developers/SDK/read-methods/getAddress
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/getAddress/
@@ -979,7 +1064,7 @@ console.log("Vault contract address:", vaultAddr);
 
 ---
 
-# Document 15: getUnderlyingDecimals()
+# Document 16: getUnderlyingDecimals()
 Source: src/03-Developers/SDK/read-methods/getUnderlyingDecimals.md
 Doc ID: Developers/SDK/read-methods/getUnderlyingDecimals
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/getUnderlyingDecimals/
@@ -1013,7 +1098,7 @@ console.log("One unit in base:", oneUnit.toString());
 
 ---
 
-# Document 16: getVaultDetails()
+# Document 17: getVaultDetails()
 Source: src/03-Developers/SDK/read-methods/getVaultDetails.md
 Doc ID: Developers/SDK/read-methods/getVaultDetails
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/getVaultDetails/
@@ -1104,7 +1189,7 @@ console.log(details.underlying.symbol);      // "LBTC"
 
 ---
 
-# Document 17: getVaultTransparencyStats (API)
+# Document 18: getVaultTransparencyStats (API)
 Source: src/03-Developers/SDK/read-methods/getVaultTransparencyStats.md
 Doc ID: Developers/SDK/read-methods/getVaultTransparencyStats
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/getVaultTransparencyStats/
@@ -1205,7 +1290,7 @@ try {
 
 ---
 
-# Document 18: getAllWithdrawQueueRequests(owner)
+# Document 19: getAllWithdrawQueueRequests(owner)
 Source: src/03-Developers/SDK/read-methods/getAllWithdrawQueueRequests.md
 Doc ID: Developers/SDK/read-methods/getAllWithdrawQueueRequests
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/getAllWithdrawQueueRequests/
@@ -1319,7 +1404,7 @@ main().catch((err) => {
 
 ---
 
-# Document 19: previewConversion(amount)
+# Document 20: previewConversion(amount)
 Source: src/03-Developers/SDK/read-methods/previewConversion.md
 Doc ID: Developers/SDK/read-methods/previewConversion
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/previewConversion/
@@ -1406,7 +1491,7 @@ console.log(
 
 ---
 
-# Document 20: totalAssets()
+# Document 21: totalAssets()
 Source: src/03-Developers/SDK/read-methods/totalAssets.md
 Doc ID: Developers/SDK/read-methods/totalAssets
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/totalAssets/
@@ -1457,7 +1542,7 @@ console.log(
 
 ---
 
-# Document 21: symbol()
+# Document 22: symbol()
 Source: src/03-Developers/SDK/read-methods/symbol.md
 Doc ID: Developers/SDK/read-methods/symbol
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/symbol/
@@ -1493,7 +1578,7 @@ console.log(await vault.symbol()); // "ctLBTC"
 
 ---
 
-# Document 22: decimals()
+# Document 23: decimals()
 Source: src/03-Developers/SDK/read-methods/decimals.md
 Doc ID: Developers/SDK/read-methods/decimals
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/decimals/
@@ -1529,7 +1614,7 @@ console.log(await vault.decimals()); // 18
 
 ---
 
-# Document 23: applyDecimals(amount)
+# Document 24: applyDecimals(amount)
 Source: src/03-Developers/SDK/read-methods/applyDecimals.md
 Doc ID: Developers/SDK/read-methods/applyDecimals
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/applyDecimals/
@@ -1561,7 +1646,7 @@ console.log("Formatted vault shares:", display);
 
 ---
 
-# Document 24: toUnderlyingDecimals(amount)
+# Document 25: toUnderlyingDecimals(amount)
 Source: src/03-Developers/SDK/read-methods/toUnderlyingDecimals.md
 Doc ID: Developers/SDK/read-methods/toUnderlyingDecimals
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/toUnderlyingDecimals/
@@ -1593,7 +1678,7 @@ console.log("Formatted underlying:", display);
 
 ---
 
-# Document 25: approve(spender, amount)
+# Document 26: approve(spender, amount)
 Source: src/03-Developers/SDK/write-methods/approve.md
 Doc ID: Developers/SDK/write-methods/approve
 Public URL: https://docs.concrete.xyz/Developers/SDK/write-methods/approve/
@@ -1649,7 +1734,7 @@ await (await vault.approve(spender, shareAllowance)).wait();
 
 ---
 
-# Document 26: deposit(amount)
+# Document 27: deposit(amount)
 Source: src/03-Developers/SDK/write-methods/deposit.md
 Doc ID: Developers/SDK/write-methods/deposit
 Public URL: https://docs.concrete.xyz/Developers/SDK/write-methods/deposit/
@@ -1699,7 +1784,7 @@ console.log("Deposit confirmed in block", receipt.blockNumber);
 
 ---
 
-# Document 27: redeem(amount)
+# Document 28: redeem(amount)
 Source: src/03-Developers/SDK/write-methods/redeem.md
 Doc ID: Developers/SDK/write-methods/redeem
 Public URL: https://docs.concrete.xyz/Developers/SDK/write-methods/redeem/
@@ -1736,7 +1821,7 @@ if (myShares > 0n) {
 
 ---
 
-# Document 28: transfer(to, amount)
+# Document 29: transfer(to, amount)
 Source: src/03-Developers/SDK/write-methods/transfer.md
 Doc ID: Developers/SDK/write-methods/transfer
 Public URL: https://docs.concrete.xyz/Developers/SDK/write-methods/transfer/
@@ -1769,7 +1854,7 @@ await (await vault.transfer(to, shareAmount)).wait();
 
 ---
 
-# Document 29: transferFrom(from, to, amount)
+# Document 30: transferFrom(from, to, amount)
 Source: src/03-Developers/SDK/write-methods/transferFrom.md
 Doc ID: Developers/SDK/write-methods/transferFrom
 Public URL: https://docs.concrete.xyz/Developers/SDK/write-methods/transferFrom/
@@ -1806,7 +1891,7 @@ await (await vault.transferFrom(owner, to, shareAmount)).wait();
 
 ---
 
-# Document 30: Decimals & Conversion Helpers
+# Document 31: Decimals & Conversion Helpers
 Source: src/03-Developers/SDK/decimals-and-conversion-helpers.md
 Doc ID: Developers/SDK/decimals-and-conversion-helpers
 Public URL: https://docs.concrete.xyz/Developers/SDK/decimals-and-conversion-helpers/
@@ -1825,7 +1910,7 @@ The following helpers cache vault decimals internally and handle conversions con
 
 ---
 
-# Document 31: Examples
+# Document 32: Examples
 Source: src/03-Developers/SDK/examples.md
 Doc ID: Developers/SDK/examples
 Public URL: https://docs.concrete.xyz/Developers/SDK/examples/
@@ -1992,7 +2077,7 @@ await (await vaultWithSigner.redeem(shares)).wait();
 
 ---
 
-# Document 32: Troubleshooting & Error Handling
+# Document 33: Troubleshooting & Error Handling
 Source: src/03-Developers/SDK/troubleshooting-and-error-handling.md
 Doc ID: Developers/SDK/troubleshooting-and-error-handling
 Public URL: https://docs.concrete.xyz/Developers/SDK/troubleshooting-and-error-handling/
@@ -2344,7 +2429,7 @@ async function retry<T>(fn: () => Promise<T>, times = 2) {
 
 ---
 
-# Document 33: Schema & Queries
+# Document 34: Schema & Queries
 Source: src/03-Developers/Subgraph-and-Events/schema-and-queries.md
 Doc ID: Developers/Subgraph-and-Events/schema-and-queries
 Public URL: https://docs.concrete.xyz/Developers/Subgraph-and-Events/schema-and-queries/
@@ -2662,7 +2747,7 @@ The `Factory` entity has no reverse-derived `vaults` field, so query the top-lev
 
 ---
 
-# Document 34: Event Reference
+# Document 35: Event Reference
 Source: src/03-Developers/Subgraph-and-Events/event-reference-and-use-cases.md
 Doc ID: Developers/Subgraph-and-Events/event-reference-and-use-cases
 Public URL: https://docs.concrete.xyz/Developers/Subgraph-and-Events/event-reference-and-use-cases/
@@ -2738,7 +2823,7 @@ The following are not on-chain events. They are subgraph-internal `@entity(times
 
 ---
 
-# Document 35: How Withdrawals Are Processed For Concrete DeFi USDT
+# Document 36: How Withdrawals Are Processed For Concrete DeFi USDT
 Source: src/04-Live-Vaults/DeFi-USDT/how-withdrawals-are-processed.md
 Doc ID: Live-Vaults/DeFi-USDT/how-withdrawals-are-processed
 Public URL: https://docs.concrete.xyz/Live-Vaults/DeFi-USDT/how-withdrawals-are-processed/
@@ -2787,7 +2872,7 @@ All withdrawals are subject to the specific terms of this vault. See [Important 
 
 ---
 
-# Document 36: Important Disclosures
+# Document 37: Important Disclosures
 Source: src/04-Live-Vaults/DeFi-USDT/important-disclosures.md
 Doc ID: Live-Vaults/DeFi-USDT/important-disclosures
 Public URL: https://docs.concrete.xyz/Live-Vaults/DeFi-USDT/important-disclosures/
@@ -2841,7 +2926,7 @@ THESE DISCLOSURES ARE PROVIDED FOR INFORMATIONAL PURPOSES ONLY AND DO NOT CONSTI
 
 ---
 
-# Document 37: WBTC Vault
+# Document 38: WBTC Vault
 Source: src/04-Live-Vaults/wbtc-vault.md
 Doc ID: Live-Vaults/wbtc-vault
 Public URL: https://docs.concrete.xyz/Live-Vaults/wbtc-vault/
@@ -2951,7 +3036,7 @@ https://docs.concrete.xyz/support/
 
 ---
 
-# Document 38: Overview
+# Document 39: Overview
 Source: src/05-Completed-Campaigns/overview.md
 Doc ID: Completed-Campaigns/overview
 Public URL: https://docs.concrete.xyz/Completed-Campaigns/overview/
@@ -2986,7 +3071,7 @@ For more on support, see [Support](https://docs.concrete.xyz/support/). For more
 
 ---
 
-# Document 39: Bera
+# Document 40: Bera
 Source: src/05-Completed-Campaigns/bera.md
 Doc ID: Completed-Campaigns/bera
 Public URL: https://docs.concrete.xyz/Completed-Campaigns/bera/
@@ -3287,7 +3372,7 @@ Claiming is quick and only requires a signature from your connected wallet.
 
 ---
 
-# Document 40: Stable
+# Document 41: Stable
 Source: src/05-Completed-Campaigns/stable.md
 Doc ID: Completed-Campaigns/stable
 Public URL: https://docs.concrete.xyz/Completed-Campaigns/stable/
@@ -3462,7 +3547,7 @@ Please refer to the main documentation's [support section](https://docs.concrete
 
 ---
 
-# Document 41: Corn
+# Document 42: Corn
 Source: src/05-Completed-Campaigns/corn.md
 Doc ID: Completed-Campaigns/corn
 Public URL: https://docs.concrete.xyz/Completed-Campaigns/corn/
@@ -3496,7 +3581,7 @@ Withdrawals are processed on Ethereum mainnet. For Corn Stables, batched withdra
 
 ---
 
-# Document 42: Morph
+# Document 43: Morph
 Source: src/05-Completed-Campaigns/morph.md
 Doc ID: Completed-Campaigns/morph
 Public URL: https://docs.concrete.xyz/Completed-Campaigns/morph/
@@ -3536,7 +3621,7 @@ Vaults that are deprecated can be exited using the in-app withdraw tab (if still
 
 ---
 
-# Document 43: TAC
+# Document 44: TAC
 Source: src/05-Completed-Campaigns/tac.md
 Doc ID: Completed-Campaigns/tac
 Public URL: https://docs.concrete.xyz/Completed-Campaigns/tac/
@@ -3607,7 +3692,7 @@ Our team will walk you through whatever steps you need.
 
 ---
 
-# Document 44: Pre-Deposit Campaigns
+# Document 45: Pre-Deposit Campaigns
 Source: src/05-Completed-Campaigns/pre-deposit-campaigns.md
 Doc ID: Completed-Campaigns/pre-deposit-campaigns
 Public URL: https://docs.concrete.xyz/Completed-Campaigns/pre-deposit-campaigns/
@@ -3629,7 +3714,7 @@ Check the vault page for two dates: when the pre-deposit period ends and when cl
 
 ---
 
-# Document 45: Audits
+# Document 46: Audits
 Source: src/06-Audits.md
 Doc ID: Audits
 Public URL: https://docs.concrete.xyz/Audits/
@@ -3839,7 +3924,7 @@ Stay tuned for upcoming enhancements and future audits as we expand our security
 
 ---
 
-# Document 46: Risks and Safety
+# Document 47: Risks and Safety
 Source: src/07-risks-and-safety.md
 Doc ID: risks-and-safety
 Public URL: https://docs.concrete.xyz/risks-and-safety/
@@ -3946,7 +4031,7 @@ Access to Concrete products is not available in every jurisdiction. Before depos
 
 ---
 
-# Document 47: Restricted Jurisdictions
+# Document 48: Restricted Jurisdictions
 Source: src/08-restricted-jurisdictions.md
 Doc ID: restricted-jurisdictions
 Public URL: https://docs.concrete.xyz/restricted-jurisdictions/
@@ -3971,7 +4056,7 @@ This list is subject to updates based on changes in international regulatory and
 
 ---
 
-# Document 48: Glossary
+# Document 49: Glossary
 Source: src/glossary.md
 Doc ID: glossary
 Public URL: https://docs.concrete.xyz/glossary/
@@ -4113,7 +4198,7 @@ This page indexes the acronyms, token tickers, and technical short-forms that sh
 
 ---
 
-# Document 49: Support
+# Document 50: Support
 Source: src/support.md
 Doc ID: support
 Public URL: https://docs.concrete.xyz/support/
@@ -4148,7 +4233,7 @@ We are working on expanding our support channels. Stay tuned for updates!
 
 ---
 
-# Document 50: How to Repay and Withdraw Borrowed Assets
+# Document 51: How to Repay and Withdraw Borrowed Assets
 Source: src/03-Borrow/close-loan.md
 Doc ID: Borrow/close-loan
 Public URL: https://docs.concrete.xyz/Borrow/close-loan/
@@ -4190,7 +4275,7 @@ Description: Concrete Borrow documentation for how to Repay and Withdraw, includ
 
 ---
 
-# Document 51: How to Activate Concrete Borrow (Default Lite)
+# Document 52: How to Activate Concrete Borrow (Default Lite)
 Source: src/03-Borrow/enable-concrete.md
 Doc ID: Borrow/enable-concrete
 Public URL: https://docs.concrete.xyz/Borrow/enable-concrete/
@@ -4259,7 +4344,7 @@ By default, Concrete Borrow comes with **Concrete Lite**, which forecloses loans
 
 ---
 
-# Document 52: How to Borrow From External Market
+# Document 53: How to Borrow From External Market
 Source: src/03-Borrow/open-loan-externally.md
 Doc ID: Borrow/open-loan-externally
 Public URL: https://docs.concrete.xyz/Borrow/open-loan-externally/
@@ -4302,7 +4387,7 @@ Concrete offers an efficient interface to initiate borrowing on external markets
 
 ---
 
-# Document 53: How to Borrow Against Collateral
+# Document 54: How to Borrow Against Collateral
 Source: src/03-Borrow/open-loan.md
 Doc ID: Borrow/open-loan
 Public URL: https://docs.concrete.xyz/Borrow/open-loan/
@@ -4357,7 +4442,7 @@ You can manage your loan in the **Portfolio** tab, which displays:
 
 ---
 
-# Document 54: Overview
+# Document 55: Overview
 Source: src/03-Borrow/overview.md
 Doc ID: Borrow/overview
 Public URL: https://docs.concrete.xyz/Borrow/overview/
@@ -4466,7 +4551,7 @@ Here’s a step-by-step outline of the complete Concrete Borrow process:
 
 ---
 
-# Document 55: Quick Start (Plug-and-Play Integration)
+# Document 56: Quick Start (Plug-and-Play Integration)
 Source: src/03-Developers/SDK/quick-start.md
 Doc ID: Developers/SDK/quick-start
 Public URL: https://docs.concrete.xyz/Developers/SDK/quick-start/
@@ -4633,7 +4718,7 @@ const deposit = useVaultDeposit(vaultConfig, options);
 
 ---
 
-# Document 56: getApyDetails()
+# Document 57: getApyDetails()
 Source: src/03-Developers/SDK/read-methods/getAPYDetails.md
 Doc ID: Developers/SDK/read-methods/getAPYDetails
 Public URL: https://docs.concrete.xyz/Developers/SDK/read-methods/getAPYDetails/
@@ -4786,7 +4871,7 @@ try {
 
 ---
 
-# Document 57: How to Activate Concrete Protect
+# Document 58: How to Activate Concrete Protect
 Source: src/04-Protect/activate-concrete-protect.md
 Doc ID: Protect/activate-concrete-protect
 Public URL: https://docs.concrete.xyz/Protect/activate-concrete-protect/
@@ -4834,7 +4919,7 @@ Users can manage all protected positions from the Portfolio:
 
 ---
 
-# Document 58: Overview
+# Document 59: Overview
 Source: src/04-Protect/overview.md
 Doc ID: Protect/overview
 Public URL: https://docs.concrete.xyz/Protect/overview/


### PR DESCRIPTION
## Summary
- Adds user-facing docs for the Withdrawal Cooldown (mechanism, bypass fee, relationship to the Withdrawal Queue)
- Documents the withdraw-modal per-lock breakdown (deposit date, Day N fee, cooldown end date)
- Documents the Portfolio lock indicator and locked-amount tooltip
- Cross-links the Cooldown Exit fee row in `fees.md`
- Addresses docs-drift missing-feature findings from Concrete-app PR #1111

## Source
- Drift artifact: https://github.com/Blueprint-Finance/Concrete-app/actions/runs/27543800753
- Caller PR: https://github.com/Blueprint-Finance/Concrete-app/pull/1111

## Test plan
- [x] `node scripts/link-glossary-terms.mjs --check` passes
- [x] Vercel preview build passes
- [x] Sidebar link `Using-Concrete-Vaults/withdrawal-cooldown` resolves
- [x] Terminology matches STYLE-AND-TERMINOLOGY.md