### PR TITLE
docs(public): Add Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -22,7 +22,7 @@ const sidebars = {
         'Using-Concrete-Vaults/vault-transparency',
         'Using-Concrete-Vaults/bridging-and-depositing-with-enso',
         'Using-Concrete-Vaults/fees',
-        'Using-Concrete-Vaults/concrete-points',
+        'Using-Concrete-Vaults/concrete-points', 'Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041',
       ],
     },
 

--- a/src/02-Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041.md
+++ b/src/02-Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041.md
@@ -1,0 +1,7 @@
+---
+title: "ZZ Public Adapter Smoke Test (DO NOT MERGE)"
+---
+
+## Public Adapter Smoke Test
+
+DO NOT MERGE. Automated smoke test for the roadmap-docs public docs adapter. Validates branch push and PR open against concrete-docs; will be closed immediately. No real content.


### PR DESCRIPTION
Adds a new page `src/02-Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041.md` (doc id `Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041`) plus a matching `sidebars.js` entry.

Generated from an approved Docs Autopilot Queue review. Opened for review; not auto-merged. This adapter never writes `llms-full.txt` (concrete-docs CI regenerates it).

<details><summary>Diff</summary>

```diff
diff --git a/sidebars.js b/sidebars.js
index 47d0f98..110c028 100644
--- a/sidebars.js
+++ b/sidebars.js
@@ -22,7 +22,7 @@ const sidebars = {
         'Using-Concrete-Vaults/vault-transparency',
         'Using-Concrete-Vaults/bridging-and-depositing-with-enso',
         'Using-Concrete-Vaults/fees',
-        'Using-Concrete-Vaults/concrete-points',
+        'Using-Concrete-Vaults/concrete-points', 'Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041',
       ],
     },
 
diff --git a/src/02-Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041.md b/src/02-Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041.md
new file mode 100644
index 0000000..4b91af3
--- /dev/null
+++ b/src/02-Using-Concrete-Vaults/zz-public-adapter-smoke-1781715687041.md
@@ -0,0 +1,7 @@
+---
+title: "ZZ Public Adapter Smoke Test (DO NOT MERGE)"
+---
+
+## Public Adapter Smoke Test
+
+DO NOT MERGE. Automated smoke test for the roadmap-docs public docs adapter. Validates branch push and PR open against concrete-docs; will be closed immediately. No real content.

```

</details>