### PR TITLE
docs(earn): vault transparency CMS visibility gate

### DIFF
--- a/src/02-Using-Concrete-Vaults/vault-transparency.md
+++ b/src/02-Using-Concrete-Vaults/vault-transparency.md
@@ -8,7 +8,7 @@ sidebar_label: "Vault Transparency"
 
 On each Earn vault page, the **Vault transparency** panel shows how that vault's off-chain portfolio is distributed across assets, protocols, and networks. Use it to see where capital is deployed without leaving the vault detail view.
 
-The panel sits in the left column of the vault page, below the withdrawal cycle section. It appears only when breakdown data is available for that vault. If no breakdown is reported, the section is hidden.
+The panel sits in the left column of the vault page, below the withdrawal cycle section. It appears only when transparency is enabled for that vault and breakdown data is available. If transparency is disabled for the vault, or if no breakdown is reported, the section is hidden.
 
 ## What you see
 

--- a/src/03-Developers/SDK/read-methods/getVaultTransparencyStats.md
+++ b/src/03-Developers/SDK/read-methods/getVaultTransparencyStats.md
@@ -77,8 +77,8 @@ Replace the base [URL](/glossary/#url) with the Concrete [API](/glossary/#api) h
 ## Notes
 
 - **Staleness**: panel copy in the app states a 24-hour delay. Cache responses accordingly; the app uses a 60-minute client cache.
-- **Empty breakdown**: when all of `byAsset`, `byProtocol`, and `byPlatform` are empty, the app hides the Vault Transparency panel.
-- **Errors**: handle non-2xx responses and network failures; the [UI](/glossary/#ui) omits the panel when data is unavailable.
+- **Empty breakdown**: when all of `byAsset`, `byProtocol`, and `byPlatform` are empty, the app hides the Vault Transparency panel. The app also hides the panel when transparency is not enabled for the vault in the content layer, even if the breakdown is non-empty.
+- **Errors**: handle non-2xx responses and network failures; the [UI](/glossary/#ui) omits the panel when data is unavailable. The app also omits the panel when transparency is not enabled for the vault, before it evaluates breakdown data.
 
 **Minimal guard**
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Concrete Docs - LLM Full Context
 
-Generated: 2026-06-12T10:01:29.312Z
+Generated: 2026-06-17T19:43:42.459Z
 Source repository: concrete-docs
 Canonical docs URL: https://docs.concrete.xyz/
 
@@ -343,7 +343,7 @@ Description: How the Vault Transparency panel on the Earn vault page shows off-c
 
 On each Earn vault page, the **Vault transparency** panel shows how that vault's off-chain portfolio is distributed across assets, protocols, and networks. Use it to see where capital is deployed without leaving the vault detail view.
 
-The panel sits in the left column of the vault page, below the withdrawal cycle section. It appears only when breakdown data is available for that vault. If no breakdown is reported, the section is hidden.
+The panel sits in the left column of the vault page, below the withdrawal cycle section. It appears only when transparency is enabled for that vault and breakdown data is available. If transparency is disabled for the vault, or if no breakdown is reported, the section is hidden.
 
 ## What you see
 
@@ -1183,8 +1183,8 @@ Replace the base [URL](https://docs.concrete.xyz/glossary/#url) with the Concret
 ## Notes
 
 - **Staleness**: panel copy in the app states a 24-hour delay. Cache responses accordingly; the app uses a 60-minute client cache.
-- **Empty breakdown**: when all of `byAsset`, `byProtocol`, and `byPlatform` are empty, the app hides the Vault Transparency panel.
-- **Errors**: handle non-2xx responses and network failures; the [UI](https://docs.concrete.xyz/glossary/#ui) omits the panel when data is unavailable.
+- **Empty breakdown**: when all of `byAsset`, `byProtocol`, and `byPlatform` are empty, the app hides the Vault Transparency panel. The app also hides the panel when transparency is not enabled for the vault in the content layer, even if the breakdown is non-empty.
+- **Errors**: handle non-2xx responses and network failures; the [UI](https://docs.concrete.xyz/glossary/#ui) omits the panel when data is unavailable. The app also omits the panel when transparency is not enabled for the vault, before it evaluates breakdown data.
 
 **Minimal guard**
 


### PR DESCRIPTION
## Summary
- Update the Vault Transparency user guide to state the panel requires per-vault transparency to be enabled, not only non-empty breakdown data
- Update `getVaultTransparencyStats` API notes so integrators know the app hides the panel when transparency is disabled in the content layer

## Source
- Drift artifact: https://github.com/Blueprint-Finance/Concrete-app/actions/runs/27714785770
- Caller PR: https://github.com/Blueprint-Finance/Concrete-app/pull/1114

## Test plan
- [x] `node scripts/link-glossary-terms.mjs --check` passes
- [x] Sidebar links unchanged; existing pages updated in place