### PR TITLE
docs(public): Update Developers/SDK/read-methods/applyDecimals

### DIFF
--- a/src/03-Developers/SDK/read-methods/applyDecimals.md
+++ b/src/03-Developers/SDK/read-methods/applyDecimals.md
@@ -27,3 +27,13 @@ console.log("Formatted vault shares:", display);
 ```json
 1.0
 ```
+
+---
+
+<!-- Added by Roadmap Docs Autopilot from approved review (run 27774904469). Non-destructive append; a docs maintainer integrates this section during PR review. -->
+
+**Why:** The pack's signature is `applyDecimals(amount: anyNumber, precision?: number): Promise<number>`, but the Parameters section lists only `amount: bigint` and omits the new optional `precision` parameter added in this PR.
+
+**Suggested fix:**
+
+Add a second parameter bullet: `- \`precision?: number\`: optional number of decimal places to round the result to. When omitted, the full decimal-adjusted value is returned.` Also broaden the amount type to `number | string | bigint`.

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Concrete Docs - LLM Full Context
 
-Generated: 2026-06-17T19:43:42.459Z
+Generated: 2026-06-18T21:19:59.179Z
 Source repository: concrete-docs
 Canonical docs URL: https://docs.concrete.xyz/
 
@@ -1558,6 +1558,16 @@ console.log("Formatted vault shares:", display);
 ```json
 1.0
 ```
+
+---
+
+<!-- Added by Roadmap Docs Autopilot from approved review (run 27774904469). Non-destructive append; a docs maintainer integrates this section during PR review. -->
+
+**Why:** The pack's signature is `applyDecimals(amount: anyNumber, precision?: number): Promise<number>`, but the Parameters section lists only `amount: bigint` and omits the new optional `precision` parameter added in this PR.
+
+**Suggested fix:**
+
+Add a second parameter bullet: `- \`precision?: number\`: optional number of decimal places to round the result to. When omitted, the full decimal-adjusted value is returned.` Also broaden the amount type to `number | string | bigint`.
 
 ---
 


### PR DESCRIPTION
Appends a reviewed section to `src/03-Developers/SDK/read-methods/applyDecimals.md` (doc id `Developers/SDK/read-methods/applyDecimals`).

The reviewed content is appended after a `---` divider under a marker comment that begins "Added by Roadmap Docs Autopilot ... Non-destructive append; a docs maintainer integrates this section during PR review." Existing prose is kept byte for byte. Please move the appended section to its final place in the page during review.

Generated from an approved Docs Autopilot Queue review. Opened for review; not auto-merged. This adapter never writes `llms-full.txt` (concrete-docs CI regenerates it).

<details><summary>Diff</summary>

```diff
diff --git a/src/03-Developers/SDK/read-methods/applyDecimals.md b/src/03-Developers/SDK/read-methods/applyDecimals.md
index 35d952f..cbd4b4d 100644
--- a/src/03-Developers/SDK/read-methods/applyDecimals.md
+++ b/src/03-Developers/SDK/read-methods/applyDecimals.md
@@ -27,3 +27,13 @@ console.log("Formatted vault shares:", display);
 ```json
 1.0
 ```
+
+---
+
+<!-- Added by Roadmap Docs Autopilot from approved review (run 27774904469). Non-destructive append; a docs maintainer integrates this section during PR review. -->
+
+**Why:** The pack's signature is `applyDecimals(amount: anyNumber, precision?: number): Promise<number>`, but the Parameters section lists only `amount: bigint` and omits the new optional `precision` parameter added in this PR.
+
+**Suggested fix:**
+
+Add a second parameter bullet: `- \`precision?: number\`: optional number of decimal places to round the result to. When omitted, the full decimal-adjusted value is returned.` Also broaden the amount type to `number | string | bigint`.

```

</details>