### PR TITLE
docs(public): Update Developers/SDK/read-methods/applyDecimals

### DIFF
--- a/src/03-Developers/SDK/read-methods/applyDecimals.md
+++ b/src/03-Developers/SDK/read-methods/applyDecimals.md
@@ -8,7 +8,8 @@ Converts a raw `BigInt` amount into a human-readable decimal-adjusted value usin
 
 ## Parameters
 
-- `amount: bigint`: raw token amount in base units.
+- `amount: anyNumber` (`number | string | bigint`): the token amount in base units to format.
+- `precision?: number` (optional): number of decimal places to round the result to. When omitted, the raw decimal-adjusted value is returned.
 
 ## Returns
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Concrete Docs - LLM Full Context
 
-Generated: 2026-06-17T19:43:42.459Z
+Generated: 2026-06-19T20:33:30.224Z
 Source repository: concrete-docs
 Canonical docs URL: https://docs.concrete.xyz/
 
@@ -1539,7 +1539,8 @@ Converts a raw `BigInt` amount into a human-readable decimal-adjusted value usin
 
 ## Parameters
 
-- `amount: bigint`: raw token amount in base units.
+- `amount: anyNumber` (`number | string | bigint`): the token amount in base units to format.
+- `precision?: number` (optional): number of decimal places to round the result to. When omitted, the raw decimal-adjusted value is returned.
 
 ## Returns
 


### PR DESCRIPTION
Replaces a section in `src/03-Developers/SDK/read-methods/applyDecimals.md` (doc id `Developers/SDK/read-methods/applyDecimals`) with the reviewed content.

The reviewed section was matched to its live heading and replaced in place, so the PR diff IS the targeted edit: review it as the near-final change. Content outside that section is kept byte for byte.

Generated from an approved Docs Autopilot Queue review. Opened for review; not auto-merged. This adapter never writes `llms-full.txt` (concrete-docs CI regenerates it).

<details><summary>Diff</summary>

```diff
diff --git a/src/03-Developers/SDK/read-methods/applyDecimals.md b/src/03-Developers/SDK/read-methods/applyDecimals.md
index 35d952f..5c4a9e2 100644
--- a/src/03-Developers/SDK/read-methods/applyDecimals.md
+++ b/src/03-Developers/SDK/read-methods/applyDecimals.md
@@ -8,7 +8,8 @@ Converts a raw `BigInt` amount into a human-readable decimal-adjusted value usin
 
 ## Parameters
 
-- `amount: bigint`: raw token amount in base units.
+- `amount: anyNumber` (`number | string | bigint`): the token amount in base units to format.
+- `precision?: number` (optional): number of decimal places to round the result to. When omitted, the raw decimal-adjusted value is returned.
 
 ## Returns
 

```

</details>