### PR TITLE
fix(style-guide): repoint glossary Source citations to post-restructure paths

### DIFF
--- a/.github/workflows/style-guide-citations.yml
+++ b/.github/workflows/style-guide-citations.yml
@@ -1,0 +1,37 @@
+name: Style guide citations
+
+# Keeps STYLE-AND-TERMINOLOGY.md's `_Source:_` citations pointing at live
+# corpus files. Runs the checker's unit tests, then the check itself: if any
+# cited `src/...` path no longer exists (a page was renamed or deleted without
+# updating the guide), the job fails and lists each dead citation. Triggers on
+# changes to the guide, to anything under src/ (a rename or delete there is
+# what makes a citation rot), and to the checker itself.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'STYLE-AND-TERMINOLOGY.md'
+      - 'src/**'
+      - 'scripts/check-style-guide-citations.mjs'
+      - 'scripts/check-style-guide-citations.test.mjs'
+      - '.github/workflows/style-guide-citations.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  style-guide-citations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run checker unit tests
+        run: node --test scripts/
+
+      - name: Check cited paths exist
+        run: node scripts/check-style-guide-citations.mjs

--- a/STYLE-AND-TERMINOLOGY.md
+++ b/STYLE-AND-TERMINOLOGY.md
@@ -399,18 +399,18 @@ items feed the translation map in Part 3.
 
 - **Concrete** – the protocol and platform. Capitalized. _Source: `src/01-Overview/welcome.md`._
 - **Concrete Protocol** – the formal protocol name, used where the legal or
-  platform entity is meant. _Source: `src/restrictions.md`._
+  platform entity is meant. _Source: `src/08-restricted-jurisdictions.md`._
 - **Concrete Earn** – the automated yield-vault product. Capitalized. Leads in
-  headers. _Source: `src/02-Earn/deposit-into-vaults.md`._
+  headers. _Source: `src/02-Using-Concrete-Vaults/deposit.md`._
 - **Earn V1 / Earn V2** – product generations. Capital "V". "Earn V2" is the
   current automated system; "Earn V1" is the legacy generation. Avoid lowercase
-  "Earn v2". _Source: `src/06-Earn-V2/overview.md`._
+  "Earn v2". _Source: `src/03-Developers/architecture-core-concepts.md`._
 - **Concrete Enterprise** – the partner offering for deploying custom vaults.
-  _Source: `src/06-Earn-V2/SDK/quick-start.md`._
+  _Source: `src/03-Developers/SDK/quick-start.md`._
 - **Concrete Points** – the incentive points distributed to users. Capitalized.
-  _Source: `src/rewards.md`, `src/05-Vaults/02-Corn/overview.md`._
+  _Source: `src/02-Using-Concrete-Vaults/concrete-points.md`, `src/05-Completed-Campaigns/corn.md`._
 - **Portfolio** – the in-app tab where a user tracks positions and withdrawal
-  status. Capitalized when naming the tab. _Source: `src/05-Vaults/how-withdrawals-work.md`._
+  status. Capitalized when naming the tab. _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 
 ### Vault mechanics
 
@@ -422,37 +422,37 @@ items feed the translation map in Part 3.
   `src/01-Overview/welcome.md`._
 - **ctAssets** – Concrete's vault shares, formatted as "ct" plus the asset
   symbol (ctUSDC, ctETH). Use the "ct" prefix. Avoid "cTokens" except when
-  specifically discussing Earn V1 naming. _Source: `src/02-Earn/ct-assets.md`._
+  specifically discussing Earn V1 naming. _Source: `src/02-Using-Concrete-Vaults/concrete-vault-shares.md`._
 - **base asset / underlying asset** – the token a vault accepts on deposit and
   pays out on withdrawal (USDC, ETH, WBTC). Avoid "deposit token" or "input
-  token". _Source: `src/01-Overview/welcome.md`, `src/05-Vaults/yield-vaults.md`._
+  token". _Source: `src/01-Overview/welcome.md`, `src/01-Overview/yield-vaults-and-erc-4626-standard.md`._
 - **ERC-4626** – the tokenized-vault standard. Always hyphenated. Avoid
-  "ERC4626". _Source: `src/01-Overview/welcome.md`. Note: `src/06-Earn-V2/Smart-Contracts/architecture.md` currently uses the unhyphenated form; the hyphenated form is canonical._
+  "ERC4626". _Source: `src/01-Overview/welcome.md`. Note: `src/03-Developers/architecture-core-concepts.md` currently uses the unhyphenated form; the hyphenated form is canonical._
 - **ERC-20** – the token standard. Always hyphenated.
 - **exchange rate / share price** – the conversion ratio between shares and the
-  underlying asset; moves with yield. _Source: `src/02-Earn/ct-assets.md`._
+  underlying asset; moves with yield. _Source: `src/02-Using-Concrete-Vaults/concrete-vault-shares.md`._
 - **NAV (Net Asset Value)** – the total value of a vault, updated daily in
-  Earn V2. Expand on first use per page. _Source: `src/05-Vaults/07-DeFi-USDT/important-disclosures.md`._
+  Earn V2. Expand on first use per page. _Source: `src/04-Live-Vaults/DeFi-USDT/important-disclosures.md`._
 - **strategy / yield strategies** – the smart contracts that deploy capital to
   earn yield (lending on Aave, liquidity on Pendle, and similar). Avoid
-  "protocol adapter" or "yield module". _Source: `src/05-Vaults/how-withdrawals-work.md`, `src/02-Earn/how-earn-vaults-maximize-risk-adjusted-yields.md`._
+  "protocol adapter" or "yield module". _Source: `src/02-Using-Concrete-Vaults/withdraw.md`, `src/03-Developers/architecture-core-concepts.md`._
 - **allocation / rebalance** – moving capital between strategies. _Source:
-  `src/02-Earn/how-earn-vaults-maximize-risk-adjusted-yields.md`._
+  `src/03-Developers/architecture-core-concepts.md`._
 - **money market** – a lending protocol (Aave, Compound, Morpho) where vault
-  strategies deploy capital. _Source: `src/05-Vaults/07-DeFi-USDT/important-disclosures.md`._
+  strategies deploy capital. _Source: `src/04-Live-Vaults/DeFi-USDT/important-disclosures.md`._
 - **Quantitative Framework** – Concrete's forecasting and allocation engine for
   risk-adjusted decisions; its signals inform target strategy weights. Capitalized.
-  _Source: `src/01-Overview/welcome.md`, `src/02-Earn/how-earn-vaults-maximize-risk-adjusted-yields.md`._
+  _Source: `src/01-Overview/welcome.md`, `src/03-Developers/architecture-core-concepts.md`._
 - **Subgraph** – the on-chain indexing service for analytics and events.
   Capitalized as the component; lowercase acceptable in generic prose. _Source:
-  `src/06-Earn-V2/Subgraph-and-Events/event-reference-and-use-cases.md`, `src/fees.md`._
+  `src/03-Developers/Subgraph-and-Events/event-reference-and-use-cases.md`, `src/02-Using-Concrete-Vaults/fees.md`._
 - **Hook** – custom logic triggered at specific vault operations; managed by the
-  Hook Manager. _Source: `src/06-Earn-V2/overview.md`._
+  Hook Manager. _Source: `src/03-Developers/architecture-core-concepts.md`._
 - **Fee Splitter** – the contract that routes fees between recipients with a
-  configurable share. _Source: `src/06-Earn-V2/overview.md`._
+  configurable share. _Source: `src/03-Developers/architecture-core-concepts.md`._
 - **pre-deposit vault** – a vault that accepts deposits on one chain before
   launching on another; withdrawals are disabled until users claim their shares
-  on the destination chain. _Source: `src/05-Vaults/01-Bera/pre-deposit-vaults-deprecation-guide.md`._
+  on the destination chain. _Source: `src/05-Completed-Campaigns/bera.md`._
 
 ### Withdrawals
 
@@ -460,12 +460,12 @@ items feed the translation map in Part 3.
   requests for predictable, fair processing. Title Case as the feature/process
   name (it leads in headers and UX); "the queue" lowercase when descriptive.
   This is the user-facing name for the system; "Epoch" is its underlying
-  mechanism. _Source: `src/05-Vaults/how-withdrawals-work.md`._
+  mechanism. _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 - **async vault / asynchronous mode** – a vault that settles withdrawals through
   the queue rather than instantly. Avoid "queued vault". _Source:
-  `src/06-Earn-V2/overview.md`, `src/06-Earn-V2/Smart-Contracts/architecture.md`._
+  `src/03-Developers/architecture-core-concepts.md`._
 - **instant withdrawal / standard mode** – atomic, same-transaction redemption,
-  available for vaults configured in standard mode. _Source: `src/06-Earn-V2/overview.md`._
+  available for vaults configured in standard mode. _Source: `src/03-Developers/architecture-core-concepts.md`._
 - **Epoch** – a vault's withdrawal accounting period; requests are processed per
   Epoch on the vault's configured cadence. Title Case as a canonical defined
   term: it is the mechanism that drives the Withdrawal Queue, and Title Case
@@ -482,27 +482,27 @@ items feed the translation map in Part 3.
   `src/02-Using-Concrete-Vaults/withdraw.md`, `src/03-Developers/architecture-core-concepts.md`._
 - **place in the queue** – a request's position in FIFO settlement order. The
   corpus phrases this as "your place in the queue"; "queue position" is an
-  acceptable noun form. _Source: `src/05-Vaults/how-withdrawals-work.md`._
+  acceptable noun form. _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 - **estimated withdrawal time** – the user-facing estimate of when funds become
-  claimable, shown in the app. _Source: `src/05-Vaults/how-withdrawals-work.md`._
+  claimable, shown in the app. _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 - **status labels: Queued, Processing, Available** – the withdrawal states shown
-  in the Portfolio tab. _Source: `src/05-Vaults/how-withdrawals-work.md`._
+  in the Portfolio tab. _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 - **FIFO (First In, First Out)** – the order in which queued requests are
   processed across Epochs. _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 - **redemption** – a withdrawal, used as a synonym in formal prose. _Source:
-  `src/05-Vaults/how-withdrawals-work.md`._
+  `src/02-Using-Concrete-Vaults/withdraw.md`._
 
 ### Yield
 
 - **yield** – the returns generated by a vault's strategies. _Source: corpus-wide._
 - **risk-adjusted yield / risk-adjusted return** – yield optimized for the
-  risk and return profile rather than headline APY. _Source: `src/01-Overview/welcome.md`, `src/02-Earn/how-earn-vaults-maximize-risk-adjusted-yields.md`._
+  risk and return profile rather than headline APY. _Source: `src/01-Overview/welcome.md`, `src/03-Developers/architecture-core-concepts.md`._
 - **yield accrual / accrued yield** – the accumulation of returns over time.
-  _Source: `src/05-Vaults/yield-vaults.md`, `src/02-Earn/balance-accrual.md`._
+  _Source: `src/01-Overview/yield-vaults-and-erc-4626-standard.md`, `src/05-Completed-Campaigns/pre-deposit-campaigns.md`._
 - **APY** – annual percentage yield; "notional APY" where the vault reports a
-  notional figure in the base asset. _Source: `src/fees.md`, `src/05-Vaults/yield-vaults.md`._
+  notional figure in the base asset. _Source: `src/02-Using-Concrete-Vaults/fees.md`, `src/01-Overview/yield-vaults-and-erc-4626-standard.md`._
 - **TVL (Total Value Locked)** – the aggregate value held across vaults.
-  _Source: `src/05-Vaults/how-withdrawals-work.md`._
+  _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 - **DeFi** – capitalized exactly. Avoid "Defi" or "defi". _Source: corpus-wide._
 - **on-chain** – hyphenated. Avoid "onchain" or "on chain". _Source: corpus-wide._
 
@@ -511,21 +511,21 @@ items feed the translation map in Part 3.
 On-chain roles are capitalized. The generic person who runs a vault is a
 lowercase "curator".
 
-- **Vault Owner** – controls upgrades for a vault. _Source: `src/06-Earn-V2/Smart-Contracts/architecture.md`._
+- **Vault Owner** – controls upgrades for a vault. _Source: `src/03-Developers/architecture-core-concepts.md`._
 - **Vault Manager** – updates parameters, limits, and fees. Avoid "admin" or unqualified "manager". _Source: `src/01-Overview/welcome.md`._
 - **Strategy Manager** – adds or removes strategies. _Source: `src/01-Overview/welcome.md`._
 - **Hook Manager** – manages hooks. _Source: `src/01-Overview/welcome.md`._
 - **Allocator** – moves capital between strategies and processes withdrawals. Capitalized. Avoid lowercase "allocator" or "fund mover". _Source: `src/01-Overview/welcome.md`._
 - **Withdrawal Manager** – handles epoch processing and claims on async vaults. _Source: `src/01-Overview/welcome.md`._
-- **Pauser** – allows the incident response team to pause the vault independently of operational roles. _Source: `src/06-Earn-V2/overview.md`._
-- **curator** – the entity managing a vault's strategy and configuration. Lowercase; descriptive, not a formal on-chain role name. _Source: `src/05-Vaults/how-withdrawals-work.md`._
+- **Pauser** – allows the incident response team to pause the vault independently of operational roles. _Source: `src/03-Developers/architecture-core-concepts.md`._
+- **curator** – the entity managing a vault's strategy and configuration. Lowercase; descriptive, not a formal on-chain role name. _Source: `src/02-Using-Concrete-Vaults/withdraw.md`._
 
 ### Fees and rewards
 
-- **management fee** – an annualized charge on vault AUM, paid by minting shares. Capped at 10%; standard configuration around 1.5%. Lowercase. _Source: `src/fees.md`._
-- **performance fee** – a charge on net positive yield, paid by minting shares. Capped at 100% of net positive yield. Lowercase. _Source: `src/fees.md`._
-- **no deposit, withdrawal, or maintenance fees** – Concrete Earn charges none of these. _Source: `src/fees.md`._
-- **BGT (Berachain Governance Token)** – earned in some Berachain vaults. _Source: `src/05-Vaults/01-Bera/`._
+- **management fee** – an annualized charge on vault AUM, paid by minting shares. Capped at 10%; standard configuration around 1.5%. Lowercase. _Source: `src/02-Using-Concrete-Vaults/fees.md`._
+- **performance fee** – a charge on net positive yield, paid by minting shares. Capped at 100% of net positive yield. Lowercase. _Source: `src/02-Using-Concrete-Vaults/fees.md`._
+- **no deposit, withdrawal, or maintenance fees** – Concrete Earn charges none of these. _Source: `src/02-Using-Concrete-Vaults/fees.md`._
+- **BGT (Berachain Governance Token)** – earned in some Berachain vaults. _Source: `src/05-Completed-Campaigns/bera.md`._
 
 ### Assets and chains
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "glossary:links": "node scripts/link-glossary-terms.mjs",
     "glossary:check": "node scripts/link-glossary-terms.mjs --check",
+    "style-guide:check": "node scripts/check-style-guide-citations.mjs",
     "test": "node --test scripts/"
   },
   "dependencies": {

--- a/scripts/check-style-guide-citations.mjs
+++ b/scripts/check-style-guide-citations.mjs
@@ -1,0 +1,68 @@
+// Verifies that every corpus path cited in STYLE-AND-TERMINOLOGY.md exists in
+// the repo tree. The glossary's `_Source:_` lines (and the inline
+// "Note: `src/...`" citation) point AI tooling at the pages each term is drawn
+// from; when a restructure renames or deletes a page without updating the
+// guide, downstream consumers copy the dead paths verbatim (this happened
+// after CONC-3738). This check fails CI with the list of dead citations.
+//
+// Usage (from repo root):
+//   node scripts/check-style-guide-citations.mjs
+//
+// Scope: every backtick-quoted token starting with `src/`. That covers all
+// `_Source:_` citations (including ones wrapped across lines, since each path
+// is a single backticked token) and the inline Note citation, while ignoring
+// cross-repo references like the concrete-app FE glossary path.
+//
+// The pure extractor (`citedPaths`) is exported for unit tests in
+// scripts/check-style-guide-citations.test.mjs. Importing this module has no
+// side effects; the filesystem check only runs when executed directly.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+export const GUIDE = 'STYLE-AND-TERMINOLOGY.md';
+
+// Extract every backtick-quoted `src/...` path token, deduplicated, in order
+// of first appearance. A trailing `/` (directory citation) is preserved;
+// existsSync handles directories the same as files.
+export function citedPaths(text) {
+  const out = [];
+  const seen = new Set();
+  const re = /`(src\/[^`]*)`/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (!seen.has(m[1])) {
+      seen.add(m[1]);
+      out.push(m[1]);
+    }
+  }
+  return out;
+}
+
+function main() {
+  const text = readFileSync(join(ROOT, GUIDE), 'utf8');
+  const cited = citedPaths(text);
+  const missing = cited.filter((p) => !existsSync(join(ROOT, p)));
+
+  if (missing.length > 0) {
+    console.error(
+      `${GUIDE} cites ${missing.length} path(s) that do not exist in the repo:`,
+    );
+    for (const p of missing) console.error(`  - ${p}`);
+    console.error(
+      '\nEach _Source:_ citation must point at a live file. If the page moved,' +
+        '\nrepoint the citation at its current location (`git log --follow -- <old-path>`' +
+        '\nshows where it went). If the page was deleted, cite the closest live' +
+        '\nsuccessor covering the same concept.',
+    );
+    process.exit(1);
+  }
+  console.log(`${GUIDE}: all ${cited.length} cited paths exist.`);
+}
+
+// Run the check only when executed directly, not when imported by tests.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/check-style-guide-citations.test.mjs
+++ b/scripts/check-style-guide-citations.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { citedPaths } from './check-style-guide-citations.mjs';
+
+test('extracts a path from a single-line Source citation', () => {
+  const text =
+    '- **vault** - a product. _Source: `src/01-Overview/welcome.md`._';
+  assert.deepEqual(citedPaths(text), ['src/01-Overview/welcome.md']);
+});
+
+test('extracts paths from a citation wrapped across lines', () => {
+  const text =
+    '- **async vault** - settles through the queue. _Source:\n' +
+    '  `src/03-Developers/architecture-core-concepts.md`._';
+  assert.deepEqual(citedPaths(text), [
+    'src/03-Developers/architecture-core-concepts.md',
+  ]);
+});
+
+test('extracts both paths from a two-path citation', () => {
+  const text =
+    '_Source: `src/01-Overview/welcome.md`, `src/02-Using-Concrete-Vaults/withdraw.md`._';
+  assert.deepEqual(citedPaths(text), [
+    'src/01-Overview/welcome.md',
+    'src/02-Using-Concrete-Vaults/withdraw.md',
+  ]);
+});
+
+test('extracts the inline Note citation', () => {
+  const text =
+    '_Source: `src/01-Overview/welcome.md`. Note: `src/03-Developers/architecture-core-concepts.md` currently uses the unhyphenated form._';
+  assert.deepEqual(citedPaths(text), [
+    'src/01-Overview/welcome.md',
+    'src/03-Developers/architecture-core-concepts.md',
+  ]);
+});
+
+test('preserves a trailing slash on directory citations', () => {
+  const text = '_Source: `src/05-Completed-Campaigns/`._';
+  assert.deepEqual(citedPaths(text), ['src/05-Completed-Campaigns/']);
+});
+
+test('deduplicates repeated citations', () => {
+  const text =
+    '_Source: `src/02-Using-Concrete-Vaults/fees.md`._\n' +
+    '_Source: `src/02-Using-Concrete-Vaults/fees.md`._';
+  assert.deepEqual(citedPaths(text), ['src/02-Using-Concrete-Vaults/fees.md']);
+});
+
+test('ignores backticked tokens that are not src/ paths', () => {
+  const text =
+    'Drawn from the FE glossary (`docs/business/_meta/glossary.md` in the concrete-app repo). ' +
+    'See `scripts/link-glossary-terms.mjs` and `/glossary/#anchor` and `yarn test`.';
+  assert.deepEqual(citedPaths(text), []);
+});
+
+test('ignores non-backticked src/ mentions in prose', () => {
+  const text = 'The corpus lives under src/ and is walked recursively.';
+  assert.deepEqual(citedPaths(text), []);
+});


### PR DESCRIPTION
## What broke

CONC-3738 (commit 484d19f, merged 2026-05-29, "docs: restructure information architecture") renamed and dissolved the `06-Earn-V2` section along with several other pre-restructure paths (`src/02-Earn/`, `src/05-Vaults/`, `src/fees.md`, `src/restrictions.md`, `src/rewards.md`, and others). `STYLE-AND-TERMINOLOGY.md` was never updated: every `_Source:_` citation in the Part 2 glossary still pointed at the dead pre-restructure paths.

## Observed downstream effect

This file ships as a sidecar to an AI documentation-drift pipeline. The model treats the `_Source:_` citations as ground truth and copies the dead paths verbatim into documentation-queue rows, producing rows that cite files that do not exist on the current default branch.

## What changed

Path strings only, in the Part 2 glossary. No prose, definitions, or terminology guidance changed. Every citation now resolves to a file that exists on `main`.

## Mapping table

| Old (dead) path | New path | How resolved |
|---|---|---|
| `src/restrictions.md` | `src/08-restricted-jurisdictions.md` | CONC-3738 renamed to `src/02-Using-Concrete-Vaults/restricted-jurisdictions.md`, later renamed again to `src/08-restricted-jurisdictions.md` |
| `src/02-Earn/deposit-into-vaults.md` | `src/02-Using-Concrete-Vaults/deposit.md` | CONC-3738 rename (R093) |
| `src/06-Earn-V2/overview.md` | `src/03-Developers/architecture-core-concepts.md` | True delete in CONC-3738, no rename pair; pointed at the closest live successor covering the same Earn V2 architecture/roles content (see judgment calls below) |
| `src/06-Earn-V2/SDK/quick-start.md` | `src/03-Developers/SDK/quick-start.md` | CONC-3738 rename (R098) |
| `src/rewards.md` | `src/02-Using-Concrete-Vaults/concrete-points.md` | CONC-3738 rename (R098) |
| `src/05-Vaults/02-Corn/overview.md` | `src/05-Completed-Campaigns/corn.md` | CONC-3738 rename (R097) |
| `src/05-Vaults/how-withdrawals-work.md` | `src/02-Using-Concrete-Vaults/withdraw.md` | CONC-3738 rename (R099) |
| `src/02-Earn/ct-assets.md` | `src/02-Using-Concrete-Vaults/concrete-vault-shares.md` | CONC-3738 rename (R096) |
| `src/05-Vaults/yield-vaults.md` | `src/01-Overview/yield-vaults-and-erc-4626-standard.md` | CONC-3738 rename (R098) |
| `src/06-Earn-V2/Smart-Contracts/architecture.md` | `src/03-Developers/architecture-core-concepts.md` | CONC-3738 rename (R097) |
| `src/05-Vaults/07-DeFi-USDT/important-disclosures.md` | `src/04-Live-Vaults/DeFi-USDT/important-disclosures.md` | CONC-3738 rename (R100) |
| `src/02-Earn/how-earn-vaults-maximize-risk-adjusted-yields.md` | `src/03-Developers/architecture-core-concepts.md` | True delete in CONC-3738, no rename pair; pointed at the closest live successor covering strategy/allocation/risk-adjusted-yield mechanics (see judgment calls below) |
| `src/06-Earn-V2/Subgraph-and-Events/event-reference-and-use-cases.md` | `src/03-Developers/Subgraph-and-Events/event-reference-and-use-cases.md` | CONC-3738 rename (R100) |
| `src/fees.md` | `src/02-Using-Concrete-Vaults/fees.md` | CONC-3738 rename (R100) |
| `src/05-Vaults/01-Bera/pre-deposit-vaults-deprecation-guide.md` | `src/05-Completed-Campaigns/bera.md` | True delete in CONC-3738, no rename pair; content verified verbatim under the "Pre-Deposit Vaults Deprecation" section of the successor page |
| `src/02-Earn/balance-accrual.md` | `src/05-Completed-Campaigns/pre-deposit-campaigns.md` | Deleted 3 days before CONC-3738 (commit 482b29e, unrelated PR #107) when its content was folded into `src/02-Earn/pre-deposit-vaults.md`, which CONC-3738 then deleted with no successor; pointed at the page that now covers the same accrued-yield-during-pre-deposit concept |
| `src/05-Vaults/01-Bera/` (directory) | `src/05-Completed-Campaigns/bera.md` | Directory removed entirely in CONC-3738; BGT content now lives in this file |

## Judgment calls (flagged for review)

Three citations pointed at files that were deleted outright in CONC-3738 with no rename pair in the diff. I pointed them at the closest live successor rather than removing the Source line, since each concept is still documented elsewhere in the corpus:

- `src/06-Earn-V2/overview.md` (cited 4 times: Earn V1/V2 generations, Hook, Fee Splitter, Pauser, async/instant withdrawal modes) had no direct successor file, but `src/03-Developers/architecture-core-concepts.md` documents the same roles, hooks, fee splitter, and async/standard vault modes in detail. Repointed there.
- `src/02-Earn/how-earn-vaults-maximize-risk-adjusted-yields.md` (cited 3 times: strategy/yield strategies, allocation/rebalance, risk-adjusted yield) had no direct successor, but `src/03-Developers/architecture-core-concepts.md` documents strategies, the Allocator, and risk-adjusted mechanics. Repointed there.
- `src/05-Vaults/01-Bera/pre-deposit-vaults-deprecation-guide.md` had no direct successor file, but its exact prose ("Pre-Deposit Vaults Deprecation... Bitcoin Bera, Ethena Bera, and Dinero Bera") is preserved verbatim in `src/05-Completed-Campaigns/bera.md`. Repointed there.

Please sanity-check these three since they involve judgment rather than a mechanical rename lookup.

## CI guard (second commit)

To keep this from recurring, the second commit adds a lint that fails PRs when any citation goes dead again:

- `scripts/check-style-guide-citations.mjs`: extracts every backticked `src/...` path cited in `STYLE-AND-TERMINOLOGY.md` (all `_Source:_` lines, including citations wrapped across lines, plus the inline "Note: `src/...`" citation) and exits 1 with a list of each cited path that does not exist in the repo tree. Cross-repo references (the concrete-app FE glossary path) are out of scope by design.
- `scripts/check-style-guide-citations.test.mjs`: unit tests for the extractor; runs under the existing `yarn test` (`node --test scripts/`) suite.
- `.github/workflows/style-guide-citations.yml`: new workflow mirroring `glossary-links.yml`, runs on PRs touching the guide, anything under `src/` (a rename or delete there is what rots a citation), or the checker itself.
- `package.json`: adds `style-guide:check`, matching the `glossary:check` convention.

Verified locally: the check passes on this branch (`STYLE-AND-TERMINOLOGY.md: all 17 cited paths exist.`, exit 0), and fails as intended when one citation is temporarily pointed back at the dead `src/fees.md` (exit 1, listing the path); the temporary change was reverted before committing.

## Not merging

Per repo convention, this PR is not self-merged. Handing to Arthur for review and merge.
